### PR TITLE
refactor: simplify Docker and README instructions for STDIO server

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,30 +1,19 @@
 # Docker Build Instructions
 
-This project uses a multi-stage Docker build to create either an HTTP API or an STDIO version of the application.
+This project uses a multi-stage Docker build to create a STDIO version of the application.
 
 ## Building with Docker
 
-### HTTP API (default)
 ```bash
-docker build -t postman-api-mcp-server .
-```
-
-### STDIO
-```bash
-docker build --target production-stdio -t postman-api-mcp-stdio .
+docker build -t postman-api-mcp-stdio .
 ```
 
 ## Running the Docker container
 
-### STDIO
 ```bash
 docker run -i -e POSTMAN_API_KEY="<your-secret-key>" postman-api-mcp-stdio
 ```
 
-### HTTP API
-```bash
-docker run -p 1337:1337 postman-api-mcp-server
-```
+The container will start the MCP server in STDIO mode, suitable for integration with editors and tools like VS Code.
 
-## Accessing the HTTP API
-You can access the HTTP API at `http://localhost:1337/mcp`. Use a tool like Postman or VS Code to connect to this endpoint. For more information about VS Code integration, see the [README](./README.md) file.
+For more information about VS Code integration, see the [README](./README.md) file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,8 @@ EXPOSE 1337
 
 ENV NODE_ENV=production
 
-FROM production-base AS production-http
-
-ENTRYPOINT ["npm", "run", "start"]
-
 FROM production-base AS production-stdio
 
 ENTRYPOINT ["npm", "run", "start:stdio"]
 
-FROM production-http AS production
+FROM production-stdio AS production

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Postman API MCP Server
 
-**This project offers two MCP-compatible server options:**
+**This project offers a single MCP-compatible server option:**
 
-1. **Streamable HTTP server** — A fully MCP-compliant server entrypoint (`dist/src/index.js`) using the [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
-2. **STDIO server** — A lightweight MCP server that communicates over standard input/output, ideal for integration with editors and tools like [VS Code](https://code.visualstudio.com/).
+- **STDIO server** — A lightweight MCP server that communicates over standard input/output, ideal for integration with editors and tools like [VS Code](https://code.visualstudio.com/).
 
 See more about the Model Context Protocol available transports in the [MCP specification](https://modelcontextprotocol.io/docs/concepts/transports).
 
@@ -25,13 +24,6 @@ You can integrate your MCP server with Visual Studio Code to use it with VS Code
           "env": {
             "POSTMAN_API_KEY": "${input:postman-api-key}"
           }
-        },
-        "postman-api-http-server": {
-          "type": "sse",
-          "url": "https://mcp.postman.com/mcp",
-          "headers": {
-            "Authorization": "Bearer ${input:postman-api-key}"
-          }
         }
       },
       "inputs": [
@@ -46,13 +38,12 @@ You can integrate your MCP server with Visual Studio Code to use it with VS Code
 
 2. Install an MCP-compatible VS Code extension (such as GitHub Copilot, Claude for VS Code, or other AI assistants that support MCP).
 
-3. Configure your extension to use one of the MCP servers:
+3. Configure your extension to use the MCP server:
 
    - **postman-api-mcp**: Uses the local stdio-based server, running directly from your project files.
      - Clone the repository
      - In the repository root folder, execute `npm install && npm run build`. This compiles the server code in the `dist` folder.
      - Make sure to replace `${workspaceFolder}` in the mcp.json file with the full path to the Postman API MCP repository.
-   - **postman-api-http-server**: Connects to the Postman cloud MCP server via [Streamable HTTP](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#streamable-http) at the /mcp endpoint. No additional steps other than setting up the mcp.json file are required.
 
 4. When prompted, enter your Postman API key.
 


### PR DESCRIPTION
This pull request removes support for the HTTP API server, streamlining the project to focus exclusively on the STDIO-based MCP server. The changes update documentation, configuration files, and Docker instructions accordingly.

### Removal of HTTP API server support:

* [`DOCKER.md`](diffhunk://#diff-972512ed94fce217ace10a2303390c321d822f967f2f008c353fb5f57152b7d0L3-R19): Removed instructions for building and running the HTTP API server. Updated Docker build commands and clarified that the container starts the MCP server in STDIO mode.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L31-R35): Removed the `production-http` stage and updated the final production stage to use `production-stdio`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R5): Updated the project description to reflect the removal of the HTTP API server, leaving only the STDIO server option. Removed references to the HTTP server in the MCP integration section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L34) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-L55)