### PR TITLE
feat: publish npm package on release

### DIFF
--- a/.github/workflows/dxt-pack.yaml
+++ b/.github/workflows/dxt-pack.yaml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+

--- a/.npmignore
+++ b/.npmignore
@@ -6,15 +6,12 @@ eslint.config.mjs
 # Development and build files
 .github/
 scripts/
-bin/act
 node_modules/
 *.log
-*.tgz
 
 # Test files
 **/*.test.ts
 **/*.test.js
-src/tests/
 
 # Documentation (except README.md which is included)
 DOCKER.md
@@ -23,20 +20,8 @@ DOCKER.md
 .git/
 .gitignore
 .vscode/
+.cursor/
 .idea/
 *.swp
 *.swo
 *~
-
-# OS files
-.DS_Store
-Thumbs.db
-
-# Environment files
-.env
-.env.local
-.env.*.local
-
-# Coverage and test output
-coverage/
-.nyc_output/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,42 @@
+# Source files (only dist/ should be published)
+src/
+tsconfig.json
+eslint.config.mjs
+
+# Development and build files
+.github/
+scripts/
+bin/act
+node_modules/
+*.log
+*.tgz
+
+# Test files
+**/*.test.ts
+**/*.test.js
+src/tests/
+
+# Documentation (except README.md which is included)
+DOCKER.md
+
+# Git and editor files
+.git/
+.gitignore
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Coverage and test output
+coverage/
+.nyc_output/

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,15 +1,25 @@
 {
-    "name": "postman-api-mcp",
-    "version": "1.2.1",
+    "name": "@postman/postman-mcp-server",
+    "version": "2.0.1",
     "description": "A simple MCP server to operate on the Postman API",
-    "main": "index.js",
+    "main": "dist/src/index.js",
     "type": "module",
     "scripts": {
         "start:stdio": "node dist/src/index.js",
         "build": "eslint --fix ./src && prettier --write \"src/**/*.ts\" && tsc",
+        "prepack": "npm run build && node scripts/sync-dist-pkg.mjs",
         "test": "vitest",
         "lint": "eslint",
         "lint:fix": "eslint --fix"
+    },
+    "bin": "dist/src/index.js",
+    "files": [
+        "dist",
+        "README.md",
+        "LICENSE"
+    ],
+    "publishConfig": {
+        "access": "public"
     },
     "dependencies": {
         "@apidevtools/swagger-parser": "^11.0.0",

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 import dotenv from 'dotenv';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,9 +4,9 @@ import unusedImports from "eslint-plugin-unused-imports";
 import eslintConfigPrettier from 'eslint-config-prettier'; // Ensures ESLint doesn't conflict with Prettier
 
 export default tseslint.config(
+  { ignores: ['dist/**', '**/*.js'] },
   {
     files: ['src/**/*.ts'],
-    ignores: ['**/*.js']
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "postman-api-mcp",
+  "name": "@postman/postman-mcp-server",
   "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "postman-api-mcp",
+      "name": "@postman/postman-mcp-server",
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -14,6 +14,9 @@
         "dotenv": "^16.5.0",
         "es-toolkit": "^1.37.2",
         "express": "^5.1.0"
+      },
+      "bin": {
+        "postman-mcp-server": "dist/src/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,25 @@
 {
-  "name": "postman-api-mcp",
+  "name": "@postman/postman-mcp-server",
   "version": "2.0.1",
   "description": "A simple MCP server to operate on the Postman API",
-  "main": "index.js",
+  "main": "dist/src/index.js",
   "type": "module",
   "scripts": {
     "start:stdio": "node dist/src/index.js",
     "build": "eslint --fix ./src && prettier --write \"src/**/*.ts\" && tsc",
+    "prepack": "npm run build && node scripts/sync-dist-pkg.mjs",
     "test": "vitest",
     "lint": "eslint",
     "lint:fix": "eslint --fix"
+  },
+  "bin": "dist/src/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^11.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 
 import dotenv from 'dotenv';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';

--- a/src/tests/integration/direct.test.ts
+++ b/src/tests/integration/direct.test.ts
@@ -84,7 +84,7 @@ describe('Postman MCP - Direct Integration Tests', () => {
     createdSpecIds = [];
   });
 
-  describe('Workspace Workflow',{ timeout: 30000 }, () => {
+  describe('Workspace Workflow', { timeout: 30000 }, () => {
     it('should create, list, search, update, and delete a single workspace', async () => {
       const workspaceData = WorkspaceDataFactory.createWorkspace();
       const workspaceId = await createWorkspace(workspaceData);
@@ -126,7 +126,7 @@ describe('Postman MCP - Direct Integration Tests', () => {
       expect(WorkspaceDataFactory.validateResponse(verifyUpdateResult)).toBe(true);
       expect((verifyUpdateResult.content as any)[0].text).toContain(updatedName);
     });
-  }, );
+  });
 
   describe('Environment Workflow', () => {
     it('should create, list, search, update, and delete a single environment', async () => {

--- a/src/tests/integration/factories/dataFactory.ts
+++ b/src/tests/integration/factories/dataFactory.ts
@@ -151,7 +151,7 @@ export class SpecDataFactory extends TestDataFactory {
     return {
       path: 'index.yaml',
       content:
-        'openapi: 3.0.0\ninfo:\n  title: My API\n  version: 1.0.0\npaths:\n  /:\n    get:\n      summary: My Endpoint\n      responses:\n        \'200\':\n          description: OK',
+        "openapi: 3.0.0\ninfo:\n  title: My API\n  version: 1.0.0\npaths:\n  /:\n    get:\n      summary: My Endpoint\n      responses:\n        '200':\n          description: OK",
       ...overrides,
     };
   }


### PR DESCRIPTION
**Build and Publishing Workflow Improvements:**

* Added a new GitHub Actions workflow (`publish.yml`) to automate publishing the package to npm when a new tag is pushed. This workflow uses Node.js 22 and ensures the package is built before publishing.
* Updated the Node.js version used in CI workflows from 20 to 22 for better compatibility and future-proofing.

**Package Structure and Publishing:**

* Renamed the package in `package.json` to `@postman/postman-mcp-server`, set the main entry point to `dist/src/index.js`, defined the `bin` field, and specified which files should be included when publishing to npm. Also added a `prepack` script to ensure the package is built and synced before publishing, and set the package to be public.
* Added a `.npmignore` file to exclude source, test, development, and configuration files from the npm package, ensuring only the necessary distribution files are published.

**Code and Configuration Updates:**

* Changed the shebang in `src/index.ts` from `tsx` to `node` to ensure compatibility when running the built JavaScript file directly.
* Updated ESLint configuration to ignore the `dist` directory and all `.js` files, preventing linting of build artifacts.
