### PR TITLE
feat: add full and minimal versions of Postman MCP server manifests

### DIFF
--- a/.github/workflows/dxt-pack.yaml
+++ b/.github/workflows/dxt-pack.yaml
@@ -21,32 +21,55 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sync manifest version with package.json
+      - name: Sync manifest versions with package.json
         run: |
           pkg_version=$(jq -r .version package.json)
-          jq --arg v "$pkg_version" '.version = $v' manifest.json > manifest.tmp.json
-          mv manifest.tmp.json manifest.json
+          jq --arg v "$pkg_version" '.version = $v' manifest-minimal.json > manifest-minimal.tmp.json
+          mv manifest-minimal.tmp.json manifest-minimal.json
+          jq --arg v "$pkg_version" '.version = $v' manifest-full.json > manifest-full.tmp.json
+          mv manifest-full.tmp.json manifest-full.json
 
       - name: Build project
         run: npm run build
 
-      - name: Install DXT
+      - name: Install dependencies for packaging
         run: npm ci --omit=dev
 
       - name: Install DXT
         run: npm install -g @anthropic-ai/dxt
 
-      - name: Package extension
+      - name: Package extensions
         run: |
-          dxt pack
           current_dir=$(basename "$PWD")
-          echo "DXT_FILENAME=${current_dir}.dxt" >> $GITHUB_ENV
+          
+          # Package minimal version
+          cp manifest-minimal.json manifest.json
+          dxt pack
+          mv "${current_dir}.dxt" "${current_dir}-minimal.dxt"
+          
+          # Package full version  
+          cp manifest-full.json manifest.json
+          dxt pack
+          mv "${current_dir}.dxt" "${current_dir}-full.dxt"
+          
+          # Set environment variables
+          echo "DXT_MINIMAL_FILENAME=${current_dir}-minimal.dxt" >> $GITHUB_ENV
+          echo "DXT_FULL_FILENAME=${current_dir}-full.dxt" >> $GITHUB_ENV
 
-      - name: Upload release asset
+      - name: Upload minimal release asset
         uses: svenstaro/upload-release-action@7027b7670c56b9473901daad1fb8a09ab534688e
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.DXT_FILENAME }}
-          asset_name: ${{ env.DXT_FILENAME }}
+          file: ${{ env.DXT_MINIMAL_FILENAME }}
+          asset_name: ${{ env.DXT_MINIMAL_FILENAME }}
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload full release asset
+        uses: svenstaro/upload-release-action@7027b7670c56b9473901daad1fb8a09ab534688e
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.DXT_FULL_FILENAME }}
+          asset_name: ${{ env.DXT_FULL_FILENAME }}
           tag: ${{ github.ref }}
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ Configure the extension to use the **postman-api-mcp** server, a local STDIO-bas
 
 ### Claude integration
 
-To integrate the MCP server with Claude, check the latest [Postman MCP server release](https://github.com/postmanlabs/postman-mcp-server/releases) and get the `.dxt` file. For more information, see Anthropic's [Claude Desktop Extensions](https://www.anthropic.com/engineering/desktop-extensions) documentation.
+To integrate the MCP server with Claude, check the latest [Postman MCP server release](https://github.com/postmanlabs/postman-mcp-server/releases) and download one of the available `.dxt` files:
+
+- **postman-api-mcp-minimal.dxt** - Contains 37 essential tools for basic Postman operations
+- **postman-api-mcp-full.dxt** - Contains all 106+ tools for comprehensive Postman functionality
+
+For more information, see Anthropic's [Claude Desktop Extensions](https://www.anthropic.com/engineering/desktop-extensions) documentation.
 
 ## Streamable HTTP
 

--- a/manifest-full.json
+++ b/manifest-full.json
@@ -1,0 +1,68 @@
+{
+  "dxt_version": "0.2",
+  "version": "",
+  "name": "postman-mcp-server-full",
+  "display_name": "Postman MCP Server (Full)",
+  "description": "A comprehensive MCP server with all available Postman API tools (106+ tools).",
+  "long_description": "This extension enables AI assistants to interact with the Postman API through Model Context Protocol (MCP). This full version provides access to all available Postman API tools including advanced features like collection forks, comments, monitors, PAN operations, and more. All secured with your Postman API key.",
+  "author": {
+    "name": "Postman, Inc.",
+    "email": "help@postman.com",
+    "url": "https://www.postman.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/postmanlabs/postman-mcp-server"
+  },
+  "homepage": "https://github.com/postmanlabs/postman-mcp-server",
+  "documentation": "https://learning.postman.com/docs/developer/postman-api/postman-mcp-server/overview",
+  "support": "https://github.com/postmanlabs/postman-api-mcp/issues",
+  "icon": "icon.png",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/src/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/src/index.js",
+        "--full"
+      ],
+      "env": {
+        "POSTMAN_API_KEY": "${user_config.postman_api_key}"
+      }
+    }
+  },
+  "keywords": [
+    "postman",
+    "api",
+    "mcp",
+    "postman-api",
+    "collections",
+    "monitors",
+    "mocks",
+    "full",
+    "comprehensive"
+  ],
+  "license": "Apache-2.0",
+  "user_config": {
+    "postman_api_key": {
+      "type": "string",
+      "title": "Postman API Key",
+      "description": "A valid Postman API key used to authenticate requests.",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  },
+  "tools_generated": true
+}

--- a/manifest-minimal.json
+++ b/manifest-minimal.json
@@ -1,10 +1,10 @@
 {
   "dxt_version": "0.2",
   "version": "",
-  "name": "postman-mcp-server",
-  "display_name": "Postman MCP Server",
-  "description": "A basic MCP server that operates using the Postman API.",
-  "long_description": "This extension enables AI assistants to interact with the Postman API through Model Context Protocol (MCP). It provides a rich set of tools for managing your collections, environments, mocks, monitors, and more, all secured with your Postman API key.",
+  "name": "postman-mcp-server-minimal",
+  "display_name": "Postman MCP Server (Minimal)",
+  "description": "A minimal MCP server with essential Postman API tools (37 tools).",
+  "long_description": "This extension enables AI assistants to interact with the Postman API through Model Context Protocol (MCP). This minimal version includes only the essential tools for basic Postman operations, providing faster performance and simplifying use for common workflows. All secured with your Postman API key.",
   "author": {
     "name": "Postman, Inc.",
     "email": "help@postman.com",
@@ -38,7 +38,8 @@
     "postman-api",
     "collections",
     "monitors",
-    "mocks"
+    "mocks",
+    "minimal"
   ],
   "license": "Apache-2.0",
   "user_config": {


### PR DESCRIPTION
- Introduced `manifest-full.json` for the comprehensive MCP server with 106+ tools.
- Introduced `manifest-minimal.json` for the essential MCP server with 37 tools.
- Updated README to include details on downloading the new `.dxt` files for both versions.
- Enhanced GitHub Actions workflow to package and upload both versions of the extension.