### PR TITLE
fix: add min and max constraints on limit parameter in getCollections schema to avoid API Drift with underlying API implementation

### DIFF
--- a/src/tools/getCollections.ts
+++ b/src/tools/getCollections.ts
@@ -21,7 +21,9 @@ export const parameters = z.object({
   limit: z
     .number()
     .int()
-    .describe('The maximum number of rows to return in the response.')
+    .min(1)
+    .max(99)
+    .describe('The number of rows to return in the response. Limit must be a positive number less than 100')
     .optional(),
   offset: z
     .number()


### PR DESCRIPTION
The input schema of the `getCollections` tool was missing min and max constraints on the `limit` parameter. This fix aligns the schema with the actual API implementation to avoid drift between the API and MCP.

More details #58 