### PR TITLE
fix: add missing required 'collection' parameter to updateMock's input schema

### DIFF
--- a/src/tools/updateMock.ts
+++ b/src/tools/updateMock.ts
@@ -19,6 +19,7 @@ export const parameters = z.object({
   mockId: z.string().describe("The mock's ID."),
   mock: z
     .object({
+      collection: z.string().describe("The associated collection's unique ID. This is a mandatory parameter."),
       name: z.string().describe("The mock server's name.").optional(),
       environment: z.string().describe("The associated environment's unique ID.").optional(),
       description: z.string().describe("The mock server's description.").optional(),


### PR DESCRIPTION
The input schema of `updateMock` tool was missing the required `collection` parameter. This update brings the schema in line with the underlying API implementation to avoid an API drift.

More details: #60 