### PR TITLE
feat: modifying github action to publish to npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and MCP Registry
 
 on:
   push:
@@ -29,4 +29,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Login to MCP Registry
+        run: |
+          echo "${{ secrets.MCP_PRIVATE_KEY }}" > key.pem
+          mcp-publisher login dns --domain postman.com --private-key-file key.pem
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
 


### PR DESCRIPTION
This pull request updates the publishing workflow to add support for publishing to the MCP Registry in addition to npm. The workflow now installs the MCP Publisher tool, logs into the MCP Registry using a private key, and publishes the package to MCP after publishing to npm.

Add MCP Registry publishing steps to workflow:

* Workflow name updated to reflect publishing to both npm and MCP Registry (`.github/workflows/publish.yml`).
* Added steps to install the MCP Publisher binary, log in to the MCP Registry using a private key, and publish the package to MCP Registry (`.github/workflows/publish.yml`).