### PR TITLE
fixes typo in claude docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Postman MCP Server supports the EU region for remote and local servers:
 * [**Remote server**](#remote-server)
   * [**VS Code**](#install-in-visual-studio-code)
   * [**Cursor**](#install-in-cursor)
-  * [**Claude Code**](#install-in-claude-code)readme
+  * [**Claude Code**](#install-in-claude-code)
 * [**Local server**](#local-server)
   * [**VS Code**](#install-in-visual-studio-code-1)
   * [**Cursor**](#install-in-cursor-1)


### PR DESCRIPTION
There's a typo in the node package name in the readme under the section for configuring claude-code. This PR fixes that typo.

EDIT: also the `--env` flag was in the wrong position, I've amended and confirmed as working. See the output of `claude mcp add --help` below.

```
❯ claude mcp add --help                                                                                        
Usage: claude mcp add [options] <name> <commandOrUrl> [args...]

Add an MCP server to Claude Code.

Examples:
  ...
  # Add stdio server:
  claude mcp add --transport stdio airtable --env AIRTABLE_API_KEY=YOUR_KEY -- npx -y airtable-mcp-server
```
This is using claude-code version 2.0.29