### PR TITLE
fix: adding key format for mcp registry login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Login to MCP Registry
         run: |
           echo "${{ secrets.MCP_PRIVATE_KEY }}" > key.pem
-          ./mcp-publisher login dns --domain postman.com --private-key key.pem
+          ./mcp-publisher login dns --domain postman.com --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish


### PR DESCRIPTION
This pull request updates the MCP Registry login step in the GitHub Actions workflow to improve how the private key is passed to the `mcp-publisher` command.