### PR TITLE
feat: add folderId parameter to runCollection for folder-specific execution

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.22.0",
         "dotenv": "^17.2.3",
-        "newman": "^6.2.0",
+        "newman": "^6.2.1",
         "uuid": "^13.0.0"
     },
     "devDependencies": {

--- a/dist/src/tools/runCollection.js
+++ b/dist/src/tools/runCollection.js
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
 import { runCollection } from './runner/index.js';
 export const method = 'runCollection';
-export const description = 'Runs a Postman collection by ID with detailed test results and execution statistics. Supports optional environment for variable substitution. Note: Advanced parameters like custom delays and other runtime options are not yet available.';
+export const description = 'Runs a Postman collection by ID with detailed test results and execution statistics. Supports optional environment for variable substitution and optional folder filtering to run only requests within a specific folder. Note: Advanced parameters like custom delays and other runtime options are not yet available.';
 export const parameters = z.object({
     collectionId: z
         .string()
@@ -11,6 +11,10 @@ export const parameters = z.object({
         .string()
         .optional()
         .describe('Optional environment ID to use for variable substitution during the run.'),
+    folderId: z
+        .string()
+        .optional()
+        .describe('Optional folder name or ID to filter the run to only requests within that folder (and nested subfolders). Folder names are preferred; IDs will be automatically resolved to names.'),
     stopOnError: z.boolean().optional().describe('Gracefully halt on errors (default: false)'),
     stopOnFailure: z
         .boolean()


### PR DESCRIPTION
## Summary

This PR adds support for executing specific folders within a Postman collection using the `runCollection` tool.

## Changes

### New Feature: Folder Execution Support

The `runCollection` tool now accepts an optional `folderId` parameter that allows running only the requests within a specific folder of a collection, rather than the entire collection.

**Implementation details:**

- Added `folderId` to the `runCollection` tool schema in `runCollection.ts`
- Added `folderId` to `CollectionRunParams` interface in `models.ts`
- Implemented `resolveFolderName()` in `executor.ts` to convert folder IDs to folder names
  - Newman's `folder` option expects folder names, not IDs
  - Supports matching by `id`, `_postman_id`, or `uid` fields
  - Falls back to the original value for direct folder name usage
- Updated `buildNewmanOptions()` to resolve folder ID before passing to Newman
- Added logging to show the resolved folder name during execution

**Usage:**

The `folderId` parameter accepts either:
- A folder ID (e.g., `17929829-d36b7575-71d6-4eee-8a48-cbda89c11af8`)
- A folder name (e.g., `Users API`)

### Bug Fixes

- **Newman Node 22 Compatibility**: Upgraded Newman to version 6.2.1 to resolve compatibility issues with Node.js 22 (undici-related errors)
- **Request Delay Removed**: Removed the 1-second `delayRequest` to improve execution speed within MCP timeout limits

## Testing

Tested with a collection containing 5 folders (16 total requests). All folders executed successfully with 100% test pass rate, completing in under 0.5 seconds each.