### PR TITLE
feat: add gemini-extension.json to support Gemini CLI

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,20 @@
+{
+    "name": "postman-api-mcp",
+    "version": "1.0.0",
+    "mcpServers": {
+        "postman-api-mcp": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "@postman/postman-mcp-server"
+            ]
+        }
+    },
+    "settings": [
+        {
+            "name": "Postman API Key",
+            "description": "Postman API Key",
+            "envVar": "POSTMAN_API_KEY"
+        }
+    ]
+}


### PR DESCRIPTION
The README states that we can use the MCP server locally with Gemini CLI using the `gemini extensions install`. ([Reference](https://github.com/shrutimantri/postman-mcp-server?tab=readme-ov-file#use-as-a-gemini-cli-extension)).

But this functionality will not work without `gemini-extension.json` being present. Hence, adding the same.