### PR TITLE
[security] sanitize environment secrets and enforce explicit confirmation for destructive actions

### DIFF
--- a/dist/src/tools/deleteCollection.js
+++ b/dist/src/tools/deleteCollection.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
 export const method = 'deleteCollection';
 export const description = 'Deletes a collection.';
@@ -6,6 +7,9 @@ export const parameters = z.object({
     collectionId: z
         .string()
         .describe('The collection ID must be in the form <OWNER_ID>-<UUID> (e.g. 12345-33823532ab9e41c9b6fd12d0fd459b8b).'),
+    confirmDeletion: z
+        .boolean()
+        .describe('CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'),
 });
 export const annotations = {
     title: 'Deletes a collection.',
@@ -14,6 +18,9 @@ export const annotations = {
     idempotentHint: true,
 };
 export async function handler(args, extra) {
+    if (args.confirmDeletion !== true) {
+        throw new McpError(ErrorCode.InvalidParams, "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion.");
+    }
     try {
         const endpoint = `/collections/${args.collectionId}`;
         const query = new URLSearchParams();

--- a/dist/src/tools/deleteEnvironment.js
+++ b/dist/src/tools/deleteEnvironment.js
@@ -1,8 +1,14 @@
 import { z } from 'zod';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
 export const method = 'deleteEnvironment';
 export const description = 'Deletes an environment.';
-export const parameters = z.object({ environmentId: z.string().describe("The environment's ID.") });
+export const parameters = z.object({
+    environmentId: z.string().describe("The environment's ID."),
+    confirmDeletion: z
+        .boolean()
+        .describe('CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'),
+});
 export const annotations = {
     title: 'Deletes an environment.',
     readOnlyHint: false,
@@ -10,6 +16,9 @@ export const annotations = {
     idempotentHint: true,
 };
 export async function handler(args, extra) {
+    if (args.confirmDeletion !== true) {
+        throw new McpError(ErrorCode.InvalidParams, "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion.");
+    }
     try {
         const endpoint = `/environments/${args.environmentId}`;
         const query = new URLSearchParams();

--- a/dist/src/tools/deleteWorkspace.js
+++ b/dist/src/tools/deleteWorkspace.js
@@ -1,8 +1,14 @@
 import { z } from 'zod';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
 export const method = 'deleteWorkspace';
 export const description = 'Deletes an existing workspace.';
-export const parameters = z.object({ workspaceId: z.string().describe("The workspace's ID.") });
+export const parameters = z.object({
+    workspaceId: z.string().describe("The workspace's ID."),
+    confirmDeletion: z
+        .boolean()
+        .describe('CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'),
+});
 export const annotations = {
     title: 'Deletes an existing workspace.',
     readOnlyHint: false,
@@ -10,6 +16,9 @@ export const annotations = {
     idempotentHint: true,
 };
 export async function handler(args, extra) {
+    if (args.confirmDeletion !== true) {
+        throw new McpError(ErrorCode.InvalidParams, "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion.");
+    }
     try {
         const endpoint = `/workspaces/${args.workspaceId}`;
         const query = new URLSearchParams();

--- a/dist/src/tools/getEnvironments.js
+++ b/dist/src/tools/getEnvironments.js
@@ -21,7 +21,23 @@ export async function handler(args, extra) {
         const options = {
             headers: extra.headers,
         };
-        const result = await extra.client.get(url, options);
+        const result = (await extra.client.get(url, options));
+        if (result && typeof result === 'object' && Array.isArray(result.environments)) {
+            result.environments.forEach((env) => {
+                if (env.values && Array.isArray(env.values)) {
+                    env.values = env.values.map((v) => {
+                        if (v.type === 'secret') {
+                            return {
+                                ...v,
+                                value: '***REDACTED BY MCP SERVER***',
+                                ...(v.initial_value ? { initial_value: '***REDACTED BY MCP SERVER***' } : {}),
+                            };
+                        }
+                        return v;
+                    });
+                }
+            });
+        }
         return {
             content: [
                 {

--- a/src/tests/security.test.ts
+++ b/src/tests/security.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handler as getEnvironmentHandler } from '../tools/getEnvironment';
+import { handler as getEnvironmentsHandler } from '../tools/getEnvironments';
+import { handler as deleteCollectionHandler } from '../tools/deleteCollection';
+
+describe('MCP Postman Server Security Hardening', () => {
+  
+  const mockClient = {
+    get: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  describe('Secret Redaction (getEnvironment - Singular)', () => {
+    // 1. Positive: Basic Redaction
+    it('should redact variables marked as secret', async () => {
+      mockClient.get.mockResolvedValue({
+        environment: {
+          values: [{ key: 'api_key', value: 'secret-123', type: 'secret' }]
+        }
+      });
+      const result = await getEnvironmentHandler({ environmentId: '123' }, { client: mockClient as any });
+      expect(result.content[0].text).toContain('***REDACTED BY MCP SERVER***');
+      expect(result.content[0].text).not.toContain('secret-123');
+    });
+
+    // 2. Positive: Initial Value Redaction
+    it('should redact both value AND initial_value for secrets', async () => {
+      mockClient.get.mockResolvedValue({
+        environment: {
+          values: [
+            { 
+              key: 'db_pass', 
+              value: 'current-top-secret', 
+              initial_value: 'original-top-secret', 
+              type: 'secret' 
+            }
+          ]
+        }
+      });
+
+      const result = await getEnvironmentHandler(
+        { environmentId: '123' }, 
+        { client: mockClient as any }
+      );
+
+      const text = result.content[0].text;
+      
+      // Check for the unique secret values, not substrings of keys
+      expect(text).not.toContain('current-top-secret');
+      expect(text).not.toContain('original-top-secret');
+      
+      // Verify redaction markers are present
+      const matches = text.match(/\*\*\*REDACTED BY MCP SERVER\*\*\*/g);
+      expect(matches?.length).toBe(2);
+    });
+
+    // 3. Negative: Integrity Check
+    it('should NOT redact variables with type "text"', async () => {
+      mockClient.get.mockResolvedValue({
+        environment: {
+          values: [{ key: 'url', value: 'https://api.com', type: 'text' }]
+        }
+      });
+      const result = await getEnvironmentHandler({ environmentId: '123' }, { client: mockClient as any });
+      expect(result.content[0].text).toContain('https://api.com');
+    });
+
+    // 4. Edge Case: Missing Type Field
+    it('should handle variables missing the type field safely', async () => {
+      mockClient.get.mockResolvedValue({
+        environment: { values: [{ key: 'unknown', value: 'some-data' }] }
+      });
+      const result = await getEnvironmentHandler({ environmentId: '123' }, { client: mockClient as any });
+      expect(result.content[0].text).toContain('some-data');
+    });
+
+    // 5. Edge Case: Missing Values Array
+    it('should handle environment object with missing values array gracefully', async () => {
+      mockClient.get.mockResolvedValue({ environment: { name: 'Empty' } });
+      const result = await getEnvironmentHandler({ environmentId: '123' }, { client: mockClient as any });
+      expect(result.content[0].text).toContain('Empty');
+    });
+
+    // 6. Edge Case: Non-JSON Response
+    it('should return raw string if API returns non-JSON', async () => {
+      mockClient.get.mockResolvedValue("Error 500");
+      const result = await getEnvironmentHandler({ environmentId: '123' }, { client: mockClient as any });
+      expect(result.content[0].text).toBe("Error 500");
+    });
+  });
+
+  describe('Bulk Redaction (getEnvironments - Plural)', () => {
+    // 7. Positive: Multi-Environment Redaction
+    it('should redact secrets across all environments in a list', async () => {
+      mockClient.get.mockResolvedValue({
+        environments: [
+          { name: 'Env1', values: [{ key: 'k1', value: 's1', type: 'secret' }] },
+          { name: 'Env2', values: [{ key: 'k2', value: 's2', type: 'secret' }] }
+        ]
+      });
+      const result = await getEnvironmentsHandler({ workspace: 'ws1' }, { client: mockClient as any });
+      expect(result.content[0].text).not.toContain('s1');
+      expect(result.content[0].text).not.toContain('s2');
+      expect(result.content[0].text.match(/\*\*\*REDACTED/g)).toHaveLength(2);
+    });
+  });
+
+  describe('Destructive Action Guardrails (deleteCollection)', () => {
+    // 8. Positive: Block if False
+    it('should throw an error if confirmDeletion is false', async () => {
+      await expect(deleteCollectionHandler({ collectionId: '123', confirmDeletion: false }, { client: mockClient as any }))
+        .rejects.toThrow('Destructive Action Blocked');
+    });
+
+    // 9. Negative: Block if Truthy String
+    it('should block if confirmDeletion is a string "true"', async () => {
+      await expect(deleteCollectionHandler({ collectionId: '123', confirmDeletion: "true" as any }, { client: mockClient as any }))
+        .rejects.toThrow('Destructive Action Blocked');
+    });
+
+    // 10. Negative: Block if Omitted
+    it('should block if confirmDeletion is omitted', async () => {
+      await expect(deleteCollectionHandler({ collectionId: '123' } as any, { client: mockClient as any }))
+        .rejects.toThrow('Destructive Action Blocked');
+    });
+
+    // 11. Positive: Pass if True
+    it('should proceed only when confirmDeletion is strictly true', async () => {
+      mockClient.delete.mockResolvedValue({ status: 'deleted' });
+      const result = await deleteCollectionHandler({ collectionId: '123', confirmDeletion: true }, { client: mockClient as any });
+      expect(result.content[0].text).toContain('deleted');
+    });
+  });
+});

--- a/src/tools/deleteCollection.ts
+++ b/src/tools/deleteCollection.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { PostmanAPIClient } from '../clients/postman.js';
-import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { IsomorphicHeaders, CallToolResult, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
 
 export const method = 'deleteCollection';
@@ -10,6 +10,11 @@ export const parameters = z.object({
     .string()
     .describe(
       'The collection ID must be in the form <OWNER_ID>-<UUID> (e.g. 12345-33823532ab9e41c9b6fd12d0fd459b8b).'
+    ),
+  confirmDeletion: z
+    .boolean()
+    .describe(
+      'CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'
     ),
 });
 export const annotations = {
@@ -23,6 +28,15 @@ export async function handler(
   args: z.infer<typeof parameters>,
   extra: { client: PostmanAPIClient; headers?: IsomorphicHeaders; serverContext?: ServerContext }
 ): Promise<CallToolResult> {
+  // --- SECURITY PATCH: Enforce Explicit Agent Confirmation ---
+  if (args.confirmDeletion !== true) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion."
+    );
+  }
+  // ----------------------------------------------------------
+
   try {
     const endpoint = `/collections/${args.collectionId}`;
     const query = new URLSearchParams();

--- a/src/tools/deleteEnvironment.ts
+++ b/src/tools/deleteEnvironment.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
 import { PostmanAPIClient } from '../clients/postman.js';
-import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { IsomorphicHeaders, CallToolResult, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
 
 export const method = 'deleteEnvironment';
 export const description = 'Deletes an environment.';
-export const parameters = z.object({ environmentId: z.string().describe("The environment's ID.") });
+export const parameters = z.object({
+  environmentId: z.string().describe("The environment's ID."),
+  confirmDeletion: z
+    .boolean()
+    .describe(
+      'CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'
+    ),
+});
 export const annotations = {
   title: 'Deletes an environment.',
   readOnlyHint: false,
@@ -17,6 +24,14 @@ export async function handler(
   args: z.infer<typeof parameters>,
   extra: { client: PostmanAPIClient; headers?: IsomorphicHeaders; serverContext?: ServerContext }
 ): Promise<CallToolResult> {
+  // --- SECURITY PATCH: Enforce Explicit Agent Confirmation ---
+  if (args.confirmDeletion !== true) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion."
+    );
+  }
+
   try {
     const endpoint = `/environments/${args.environmentId}`;
     const query = new URLSearchParams();

--- a/src/tools/deleteWorkspace.ts
+++ b/src/tools/deleteWorkspace.ts
@@ -1,22 +1,37 @@
 import { z } from 'zod';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { PostmanAPIClient } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
 
 export const method = 'deleteWorkspace';
 export const description = 'Deletes an existing workspace.';
-export const parameters = z.object({ workspaceId: z.string().describe("The workspace's ID.") });
+// 1. Update the schema to require a boolean flag
+export const parameters = z.object({
+  workspaceId: z.string().describe("The workspace's ID."),
+  confirmDeletion: z
+    .boolean()
+    .describe(
+      'CRITICAL SAFETY FLAG: You MUST explicitly ask the user for confirmation before executing this tool. Set to true only after the user agrees.'
+    ),
+});
 export const annotations = {
   title: 'Deletes an existing workspace.',
   readOnlyHint: false,
   destructiveHint: true,
   idempotentHint: true,
 };
-
 export async function handler(
   args: z.infer<typeof parameters>,
   extra: { client: PostmanAPIClient; headers?: IsomorphicHeaders; serverContext?: ServerContext }
 ): Promise<CallToolResult> {
+  // 2. Add the guardrail before hitting the API
+  if (args.confirmDeletion !== true) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "Destructive Action Blocked: You must explicitly ask the user for permission and set 'confirmDeletion' to true to execute this deletion."
+    );
+  }
   try {
     const endpoint = `/workspaces/${args.workspaceId}`;
     const query = new URLSearchParams();

--- a/src/tools/getEnvironment.ts
+++ b/src/tools/getEnvironment.ts
@@ -17,14 +17,47 @@ export async function handler(
   args: z.infer<typeof parameters>,
   extra: { client: PostmanAPIClient; headers?: IsomorphicHeaders; serverContext?: ServerContext }
 ): Promise<CallToolResult> {
-  try {
+ try {
     const endpoint = `/environments/${args.environmentId}`;
     const query = new URLSearchParams();
     const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
     const options: any = {
       headers: extra.headers,
     };
-    const result = await extra.client.get(url, options);
+    
+    const result = await extra.client.get(url, options) as any;
+
+    // --- SECURITY PATCH: Redact secret variables ---
+    // if (result && typeof result === 'object' && result.environment && Array.isArray(result.environment.values)) {
+    //   result.environment.values = result.environment.values.map((v: any) => {
+    //     if (v.type === 'secret') {
+    //       return { 
+    //         ...v, 
+    //         value: '***REDACTED BY MCP SERVER***', 
+    //         // Postman sometimes returns initial_value depending on API version
+    //         ...(v.initial_value ? { initial_value: '***REDACTED BY MCP SERVER***' } : {}) 
+    //       };
+    //     }
+    //     return v;
+    //   });
+    // }
+
+    if (result?.environment?.values && Array.isArray(result.environment.values)) {
+      result.environment.values = result.environment.values.map((v: any) => {
+        if (v.type === 'secret') {
+          const redacted = '***REDACTED BY MCP SERVER***';
+          return { 
+            ...v, 
+            value: redacted,
+            // Ensure both common Postman API variants are caught and overwritten
+            ...(v.initial_value !== undefined ? { initial_value: redacted } : {}),
+            ...(v.initialValue !== undefined ? { initialValue: redacted } : {})
+          };
+        }
+        return v;
+      });
+    } 
+
     return {
       content: [
         {
@@ -33,7 +66,7 @@ export async function handler(
         },
       ],
     };
-  } catch (e: unknown) {
+  }catch (e: unknown) {
     if (e instanceof McpError) {
       throw e;
     }

--- a/src/tools/getEnvironments.ts
+++ b/src/tools/getEnvironments.ts
@@ -29,7 +29,30 @@ export async function handler(
     const options: any = {
       headers: extra.headers,
     };
-    const result = await extra.client.get(url, options);
+    
+    const result = await extra.client.get(url, options) as any;
+
+    // --- SECURITY PATCH: Redact secrets if present in list view ---
+    if (result?.environments && Array.isArray(result.environments)) {
+      result.environments.forEach((env: any) => {
+        if (env.values && Array.isArray(env.values)) {
+          env.values = env.values.map((v: any) => {
+            if (v.type === 'secret') {
+              const redacted = '***REDACTED BY MCP SERVER***';
+              return { 
+                ...v, 
+                value: redacted,
+                ...(v.initial_value !== undefined ? { initial_value: redacted } : {}),
+                ...(v.initialValue !== undefined ? { initialValue: redacted } : {})
+              };
+            }
+            return v;
+          });
+        }
+      });
+    }
+    // -------------------------------------------------------------
+
     return {
       content: [
         {


### PR DESCRIPTION
## Description:
This PR hardens the Postman MCP Server against two critical AI agent threat vectors: Sensitive Information Disclosure (Secret Exfiltration) and Unintended Destructive Actions (Blast Radius).

1. Secret Exfiltration Prevention (getEnvironment.ts)

Context: The Postman API returns the values of all environment variables, including those marked as type: 'secret'. Previously, the MCP server passed this raw JSON directly to the LLM. If an agent inspected a production environment, it ingested plaintext credentials into its context window, creating a massive exfiltration risk.

Fix: Intercepts the API response and explicitly redacts value and initial_value for any variable where type === 'secret' before serializing the payload for the LLM.

2. Agentic Blast Radius Mitigation (deleteWorkspace.ts)

Context: While the tool used destructiveHint: true, this only protects human-in-the-loop GUI clients. Headless or fully autonomous agents could hallucinate a call to deleteWorkspace, instantly vaporizing user data without friction.

Fix: Updated the Zod schema to require a mandatory confirmDeletion: boolean parameter. The prompt description explicitly instructs the LLM to halt and ask the user for human confirmation before setting this flag. The handler enforces this natively, throwing an InvalidParams error if bypassed.

## Tests

Unit Tests added