### PR TITLE
Document 'Quiet' mode for MCP server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ To install the MCP server in Windsurf, do the following:
 1. Select the tools that you want to enable, or click **All Tools** to select all available tools.
 1. Turn on **Enabled** to enable the Postman MCP server.
 
-> Windows users running Windsurf may run into a timeout on startup. The problem: Windsurf's Go-based MCP client doesn't drain the stderr pipe quickly enough, so the ~120 "Loaded tool" log messages that fire at startup flood the 4KB pipe buffer. Once that buffer fills, Node.js `console.error()` calls start blocking. Because those calls are blocking the event loop, the server never gets a chance to respond to the MCP initialize request before Windsurf's 60-second timeout kicks in. The `--quiet` flag suppresses the startup logs and prevents the pipe from reaching its buffer limit.
+> Windows users on Windsurf can hit a startup timeout because too many startup logs fill the stderr buffer, which blocks the server before MCP initialization completes. Using the `--quiet` configuration suppresses those logs and avoids the issue.
 
 #### Manual installation
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ codex mcp add postman --env POSTMAN_API_KEY=<POSTMAN_API_KEY> -- npx @postman/po
 
 ### Install in Windsurf
 
-To manually install the MCP server in Windsurf, do the following:
+To install the MCP server in Windsurf, do the following:
 
 1. Click **Open MCP Marketplace** in Windsurf.
 1. Type "Postman" in the search text box to filter the marketplace results.
@@ -575,6 +575,8 @@ To manually install the MCP server in Windsurf, do the following:
 1. When prompted, enter a valid Postman API key.
 1. Select the tools that you want to enable, or click **All Tools** to select all available tools.
 1. Turn on **Enabled** to enable the Postman MCP server.
+
+> Windows users running Windsurf may run into a timeout on startup. The problem: Windsurf's Go-based MCP client doesn't drain the stderr pipe quickly enough, so the ~120 "Loaded tool" log messages that fire at startup flood the 4KB pipe buffer. Once that buffer fills, Node.js `console.error()` calls start blocking. Because those calls are blocking the event loop, the server never gets a chance to respond to the MCP initialize request before Windsurf's 60-second timeout kicks in. The `--quiet` flag suppresses the startup logs and prevents the pipe from reaching its buffer limit.
 
 #### Manual installation
 
@@ -601,8 +603,6 @@ Copy the following JSON config into the `.codeium/windsurf/mcp_config.json` file
     }
 }
 ```
-
-> Windows users running Windsurf may run into a timeout on startup. The problem: Windsurf's Go-based MCP client doesn't drain the stderr pipe quickly enough, so the ~120 "Loaded tool" log messages that fire at startup flood the 4KB pipe buffer. Once that buffer fills, Node.js `console.error()` calls start blocking. Because those calls are blocking the event loop, the server never gets a chance to respond to the MCP initialize request before Windsurf's 60-second timeout kicks in. The `--quiet` flag suppresses the startup logs and prevents the pipe from reaching its buffer limit.
 
 ### Install in Antigravity
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ The local server supports the following tool configurations:
 * **Minimal** — (Default) Only includes essential tools for basic Postman operations.
 * **Code** — Includes tools for searching public and internal API definitions and generating client code.
 * **Full** — Includes all available Postman API tools (100+ tools).
+* **Quiet** — This option suppresses `debug` and `info` logs in stderr, and returns only `warn` and `error`. This mode is required for **Windsurf** users on Windows, as it avoids a stderr pipe buffer deadlock that results in MCP initializing a request to timeout. You can enable this mode along with the the **Minimal**, **Code**, or **Full** configuration.
 
 **Note:**
 * Use the `--region` flag to specify the Postman API region (`us` or `eu`), or set the `POSTMAN_API_BASE_URL` environment variable directly. By default, the server uses the `us` option.
@@ -584,7 +585,11 @@ Copy the following JSON config into the `.codeium/windsurf/mcp_config.json` file
     "mcpServers": {
         "postman": {
             "args": [
-                "@postman/postman-mcp-server"
+                "@postman/postman-mcp-server",
+                "--minimal" // (Default) Use this flag to enable minimal mode.
+                // "--full" — Use this flag to enable full mode.
+                // "--code" — Use this flag to enable code mode.
+                // "--quiet" — Use this flag to enable quiet mode alongside your mode of choice.
             ],
             "command": "npx",
             "disabled": false,
@@ -596,6 +601,8 @@ Copy the following JSON config into the `.codeium/windsurf/mcp_config.json` file
     }
 }
 ```
+
+> Windows users running Windsurf may run into a timeout on startup. The problem: Windsurf's Go-based MCP client doesn't drain the stderr pipe quickly enough, so the ~120 "Loaded tool" log messages that fire at startup flood the 4KB pipe buffer. Once that buffer fills, Node.js `console.error()` calls start blocking. Because those calls are blocking the event loop, the server never gets a chance to respond to the MCP initialize request before Windsurf's 60-second timeout kicks in. The `--quiet` flag suppresses the startup logs and prevents the pipe from reaching its buffer limit.
 
 ### Install in Antigravity
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ The local server supports the following tool configurations:
 * **Minimal** — (Default) Only includes essential tools for basic Postman operations.
 * **Code** — Includes tools for searching public and internal API definitions and generating client code.
 * **Full** — Includes all available Postman API tools (100+ tools).
-* **Quiet** — This option suppresses `debug` and `info` logs in stderr, and returns only `warn` and `error`. This mode is required for **Windsurf** users on Windows, as it avoids a stderr pipe buffer deadlock that results in MCP initializing a request to timeout. You can enable this mode along with the the **Minimal**, **Code**, or **Full** configuration.
+* **Quiet** — This option suppresses `debug` and `info` logs in stderr, and returns only `warn` and `error`. This mode is required for **Windsurf** users on Windows, as it avoids a stderr pipe buffer deadlock that results in MCP initializing a request to timeout. You can enable this mode along with the **Minimal**, **Code**, or **Full** configuration.
 
 **Note:**
 * Use the `--region` flag to specify the Postman API region (`us` or `eu`), or set the `POSTMAN_API_BASE_URL` environment variable directly. By default, the server uses the `us` option.


### PR DESCRIPTION
## Jira
[PSTAPI-1214](https://postmanlabs.atlassian.net/browse/PSTAPI-1214)

## Description

Added 'Quiet' mode option to suppress logs for Windsurf users in stdio mode. The changes:

New entry in the _Local server_ (stdio) supported configs section:
<img width="635" height="101" alt="Screenshot 2026-04-01 at 12 53 15 PM" src="https://github.com/user-attachments/assets/6391ee34-3bf4-4280-baff-9e29389ac121" />

A note in the stdio Windsurf section:
<img width="628" height="410" alt="image" src="https://github.com/user-attachments/assets/56aa1e93-03b1-456c-8d53-4a94f47cfb20" />


[PSTAPI-1214]: https://postmanlabs.atlassian.net/browse/PSTAPI-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ