### PR TITLE
fix(collections): support nested folder items in createCollection / putCollection (closes #142)

### DIFF
--- a/src/tools/createCollection.ts
+++ b/src/tools/createCollection.ts
@@ -618,6 +618,12 @@ export const parameters = z.object({
                 'The [settings](https://learning.postman.com/docs/sending-requests/create-requests/request-settings/) used to alter the [Protocol Profile Behavior](https://github.com/postmanlabs/postman-runtime/blob/develop/docs/protocol-profile-behavior.md) of sending a request.'
               )
               .optional(),
+            item: z
+              .array(z.unknown())
+              .describe(
+                'For folder items, a list of nested items (requests or further folders). See the [Postman Collection v2.1.0 spec](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html) — an item may be either a request (has a `request` property) or a folder (has an `item` array).'
+              )
+              .optional(),
           })
           .describe('Information about the collection request or folder.')
       ),

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -171,6 +171,7 @@ export const parameters = z.object({
                   .object({
                     type: z
                       .enum([
+                        'noauth',
                         'basic',
                         'bearer',
                         'apikey',
@@ -703,6 +704,12 @@ export const parameters = z.object({
               .describe('The date and time at which the collection item was updated.')
               .optional(),
             uid: z.string().describe("The collection item's unique ID.").optional(),
+            item: z
+              .array(z.unknown())
+              .describe(
+                'For folder items, a list of nested items (requests or further folders). See the [Postman Collection v2.1.0 spec](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html) — an item may be either a request (has a `request` property) or a folder (has an `item` array).'
+              )
+              .optional(),
           })
           .describe('Information about the collection request or folder.')
       ),
@@ -770,6 +777,7 @@ export const parameters = z.object({
         .object({
           type: z
             .enum([
+              'noauth',
               'basic',
               'bearer',
               'apikey',


### PR DESCRIPTION
## Context

Closes #142 (also tracked internally as **PSTAPI-1255**).

Per the [Postman Collection v2.1.0 spec](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html), an \`item\` can be **either**:
- a **request item** (has a \`request\` property), or
- a **folder item** (has a nested \`item\` array).

The Zod input schemas in \`createCollection.ts\` and \`putCollection.ts\` only modelled the request-item case — there was no \`item\` field on the inline item object. Because Zod's default \`.object()\` behaviour strips unknown keys, folder payloads supplied by callers (e.g. Claude Code, Gemini) had their nested \`item: [...]\` silently removed **before** being forwarded to the Postman API, which then rejected the request with the \`oneOf\` error reported in the issue:

\`\`\`
"item/0: must have required property 'request'"
"item/0: must have required property 'item'"
"item/0: must match exactly one schema in oneOf"
\`\`\`

## Changes

### Primary fix (the #142 complaint)

Added \`item: z.array(z.unknown()).optional()\` to the request-item object in both \`createCollection.ts\` and \`putCollection.ts\`:

\`\`\`ts
item: z
  .array(z.unknown())
  .describe(
    'For folder items, a list of nested items (requests or further folders). See the Postman Collection v2.1.0 spec — an item may be either a request (has a \`request\` property) or a folder (has an \`item\` array).'
  )
  .optional(),
\`\`\`

Design notes:
- Typed as \`z.array(z.unknown())\` rather than a recursively-typed \`z.lazy(() => itemSchema)\`. The tradeoff is deliberately small: the two existing item schemas in this repo already total ~1,200 lines and diverge between \`createCollection\` and \`putCollection\` (the latter adds \`id\` / \`uid\` / \`updatedAt\` fields). A recursive self-referencing schema per file would require extracting each 600-line object literal into a named \`z.lazy\` const, inflating the diff to ~1,300 lines of mostly-unchanged code without improving correctness — the authoritative v2.1.0 validation happens on the Postman API anyway, which is what surfaced the original error.
- The \`.describe()\` copy makes the folder-vs-request dichotomy explicit for MCP clients browsing the tool schema (Claude Code / Gemini / etc.).

### Secondary fix (\`noauth\` parity in \`putCollection\`)

The issue also flagged: *"putCollection does not support \`noauth\` in the auth type enum (while createCollection does in its schema definition)"*. Added \`'noauth'\` as the first entry of both \`auth.type\` enums in \`putCollection.ts\` (request-level at line 174, collection-level at line 780) so the two tools expose the same auth-type surface.

## Test plan

With this patch:

1. **Folder creation** — pass a folder-containing collection to \`createCollection\`:
   \`\`\`json
   {
     "collection": {
       "info": {
         "name": "Test",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
       },
       "item": [
         {
           "name": "My Folder",
           "item": [
             { "name": "My Request", "request": { "method": "GET", "url": "https://example.com" } }
           ]
         }
       ]
     }
   }
   \`\`\`
   - [ ] Zod now accepts the payload (\`item\` on the folder is preserved).
   - [ ] Postman API returns the created collection successfully, with the folder hierarchy intact.

2. **Folder update** — same payload through \`putCollection\` (with a \`collectionId\`):
   - [ ] Folder is updated / preserved, not flattened.

3. **\`noauth\` parity** — pass \`{ auth: { type: "noauth" } }\` at both request-level and collection-level through \`putCollection\`:
   - [ ] Zod accepts \`noauth\` (no enum-validation error).
   - [ ] Postman API accepts the payload.

4. **Regression** — existing request-only collection creations (no folders) still work unchanged.
5. **Vitest / lint** — \`pnpm run lint\` and \`pnpm run test\` remain green; no existing type signatures were touched.

## What this PR does *not* do (follow-ups)

- Doesn't introduce a recursively-typed folder schema. A follow-up PR can replace \`z.unknown()\` with a \`z.lazy\`-based self-reference once the maintainers have an opinion on how much of the v2.1.0 spec they want mirrored in Zod vs. delegated to the Postman API.
- Doesn't add integration test coverage — \`src/tests/integration/direct.test.ts\` hits the live Postman API (needs \`POSTMAN_API_KEY\`), so a folder-creation test would be better added by someone with CI-authenticated access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)