### PR TITLE
feat: remove context tools from full toolset

### DIFF
--- a/src/enabledResources.ts
+++ b/src/enabledResources.ts
@@ -160,17 +160,6 @@ const full = [
   // Analytics
   'getAnalyticsData',
   'getAnalyticsMetadata',
-
-  // Context (AI-optimized markdown views)
-  'getCollectionContext',
-  'getFolderContext',
-  'getRequestContext',
-  'getResponseContext',
-  'getRequestCodeContext',
-  'getEnvironmentContext',
-  'getWorkspacesContext',
-  'getWorkspaceContext',
-  'getWorkspaceEnvironmentsContext',
 ] as const;
 
 const minimal = [


### PR DESCRIPTION
## Summary
- Removes the nine `*Context` tools from the `full` toolset in `src/enabledResources.ts`
- These AI-optimized markdown view tools remain available only in the `code` toolset, where they belong

## Test plan
- [ ] Verify `full` toolset no longer exposes `getCollectionContext`, `getFolderContext`, `getRequestContext`, `getResponseContext`, `getRequestCodeContext`, `getEnvironmentContext`, `getWorkspacesContext`, `getWorkspaceContext`, `getWorkspaceEnvironmentsContext`
- [ ] Verify `code` toolset still exposes all of the above
- [ ] `getEnabledTools` output reflects the change

Generated with [Claude Code](https://claude.com/claude-code)