### PR TITLE
chore(postman.yaml): declare published npm packages [PLAT-1265]

### DIFF
--- a/postman.yaml
+++ b/postman.yaml
@@ -1,0 +1,19 @@
+---
+# postman.yaml
+# Library that publishes one or more npm packages. Filed under PLAT-1265.
+#
+# Sources used to populate this file:
+#  - description: GitHub repo description
+#  - npmPackages: package-to-repo verification at HIGH confidence (commit 2fba6bf
+#    in postman-eng/cloud9-claude, audit dated 2026-05-21)
+name: "postman-mcp-server"
+friendlyName: "Postman Mcp Server"
+description: "Connect your AI to your APIs on Postman"
+type: "LIB"
+owner: "akira28 (from CODEOWNERS)"
+dataClass: "Public"
+containsCustomerData: false
+requiredInSelfHosted: false
+npmPackages:
+- name: "@postman/postman-mcp-server"
+  path: "package.json"


### PR DESCRIPTION
See PLAT-1265 for audit context.
Generated with [Claude Code](https://claude.com/claude-code)