### PR TITLE
fix: folder items and events array schema fixes (#142, #144)

### DIFF
--- a/src/tools/createCollection.ts
+++ b/src/tools/createCollection.ts
@@ -798,6 +798,7 @@ export const parameters = z.object({
               )
               .optional(),
           })
+          .optional()
           .describe('Information about the collection request or folder.')
       ),
       event: z

--- a/src/tools/createCollectionRequest.ts
+++ b/src/tools/createCollectionRequest.ts
@@ -408,7 +408,7 @@ export const parameters = z.object({
           .optional(),
       })
     )
-    .nullable()
+    .nullish()
     .describe('A list of scripts configured to run when specific events occur.')
     .optional(),
 });

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -887,6 +887,7 @@ export const parameters = z.object({
               )
               .optional(),
           })
+          .optional()
           .describe('Information about the collection request or folder.')
       ),
       event: z

--- a/src/tools/updateCollectionRequest.ts
+++ b/src/tools/updateCollectionRequest.ts
@@ -398,7 +398,7 @@ export const parameters = z.object({
           .optional(),
       })
     )
-    .nullable()
+    .nullish()
     .describe('A list of scripts configured to run when specific events occur.')
     .optional(),
 });

--- a/src/tools/updateCollectionRequest.ts
+++ b/src/tools/updateCollectionRequest.ts
@@ -431,7 +431,23 @@ export async function handler(
     if (args.graphqlModeData !== undefined) bodyPayload.graphqlModeData = args.graphqlModeData;
     if (args.dataOptions !== undefined) bodyPayload.dataOptions = args.dataOptions;
     if (args.auth !== undefined) bodyPayload.auth = args.auth;
-    if (args.events !== undefined) bodyPayload.events = args.events;
+    if (args.events !== undefined) {
+      // Fetch existing request to get current events and merge by listen type
+      const existingRequest = await extra.client.get<{ events?: any[] }>(endpoint);
+      const existingEvents = existingRequest?.events ?? [];
+      // Build a map of existing events keyed by listen type
+      const eventsMap = new Map<string, any>();
+      for (const event of existingEvents) {
+        if (event.listen) {
+          eventsMap.set(event.listen, event);
+        }
+      }
+      // Merge incoming events, overwriting existing ones by listen type
+      for (const event of args.events) {
+        if (event.listen) eventsMap.set(event.listen, event);
+      }
+      bodyPayload.events = Array.from(eventsMap.values());
+    }
     const options: any = {
       body: JSON.stringify(bodyPayload),
       contentType: ContentType.Json,


### PR DESCRIPTION
Fixes #142

Fixes #144

The item schema in createCollection and putCollection tools required  without making it optional. This caused validation errors when trying to create nested folder items, which have  but no  field.

This fix makes the top-level item's  field optional (), allowing both request items (with ) and folder items (with  only) to be valid.