### PR TITLE
fix: MCP stdio dotenv quiet + events array schema

### DIFF
--- a/dist/src/env.js
+++ b/dist/src/env.js
@@ -1,4 +1,6 @@
+import dotenv from 'dotenv';
 import { z } from 'zod';
+dotenv.config({ quiet: true });
 const envSchema = z.object({
     POSTMAN_API_KEY: z.string(),
     POSTMAN_API_BASE_URL: z.string().url().default('https://api.postman.com'),

--- a/dist/src/tools/createCollectionRequest.js
+++ b/dist/src/tools/createCollectionRequest.js
@@ -336,7 +336,6 @@ export const parameters = z.object({
             .describe('Information about the Javascript code that can be used to to perform setup or teardown operations in a response.')
             .optional(),
     }))
-        .nullable()
         .describe('A list of scripts configured to run when specific events occur.')
         .optional(),
 });

--- a/dist/src/tools/updateCollectionRequest.js
+++ b/dist/src/tools/updateCollectionRequest.js
@@ -330,7 +330,6 @@ export const parameters = z.object({
             .describe('Information about the Javascript code that can be used to to perform setup or teardown operations in a response.')
             .optional(),
     }))
-        .nullable()
         .describe('A list of scripts configured to run when specific events occur.')
         .optional(),
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,9 +1,13 @@
+import dotenv from 'dotenv';
 import { z } from 'zod';
 
 /**
  * Public environment configuration for the Postman MCP Server (STDIO mode).
  * This file contains only the variables needed for the public open-source version.
  */
+
+// dotenv v17 logs to stdout by default; MCP stdio transport uses stdout for JSON-RPC.
+dotenv.config({ quiet: true });
 
 const envSchema = z.object({
   POSTMAN_API_KEY: z.string(),

--- a/src/tests/env.test.ts
+++ b/src/tests/env.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { parameters as createRequestParameters } from '../tools/createCollectionRequest.js';
+import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
+import { objectFromShape } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+
+const envModuleUrl = new URL('../../dist/src/env.js', import.meta.url).href;
+
+describe('env loading', () => {
+  it('does not write dotenv info messages to stdout when .env is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'postman-mcp-env-'));
+    const result = spawnSync(process.execPath, ['-e', `import('${envModuleUrl}')`], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, POSTMAN_API_KEY: 'test-key' },
+    });
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('loads POSTMAN_API_KEY from a .env file in the working directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'postman-mcp-env-'));
+    writeFileSync(join(dir, '.env'), 'POSTMAN_API_KEY=from-dotenv-file\n');
+    const childEnv = { ...process.env };
+    delete childEnv.POSTMAN_API_KEY;
+    const result = spawnSync(
+      process.execPath,
+      ['-e', `import('${envModuleUrl}').then((m) => console.log(m.env.POSTMAN_API_KEY))`],
+      {
+        cwd: dir,
+        encoding: 'utf8',
+        env: childEnv,
+      }
+    );
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('from-dotenv-file');
+  });
+});
+
+describe('createCollectionRequest schema', () => {
+  it('exposes events as a top-level array type for MCP clients', () => {
+    const json = toJsonSchemaCompat(objectFromShape(createRequestParameters.shape));
+    expect(json.properties?.events).toMatchObject({ type: 'array' });
+  });
+});

--- a/src/tests/vitest.setup.ts
+++ b/src/tests/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.env.POSTMAN_API_KEY ??= 'test-api-key';

--- a/src/tools/createCollectionRequest.ts
+++ b/src/tools/createCollectionRequest.ts
@@ -408,7 +408,6 @@ export const parameters = z.object({
           .optional(),
       })
     )
-    .nullable()
     .describe('A list of scripts configured to run when specific events occur.')
     .optional(),
 });

--- a/src/tools/updateCollectionRequest.ts
+++ b/src/tools/updateCollectionRequest.ts
@@ -398,7 +398,6 @@ export const parameters = z.object({
           .optional(),
       })
     )
-    .nullable()
     .describe('A list of scripts configured to run when specific events occur.')
     .optional(),
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     include: ['src/tests/**/*.test.ts'],
     globals: true,
-    setupFiles: [],
+    setupFiles: ['src/tests/vitest.setup.ts'],
     testTimeout: 180000, // 2 minutes
     hookTimeout: 180000, // 1 minute for hooks (beforeAll, afterAll)
     teardownTimeout: 180000, // 100 seconds for cleanup


### PR DESCRIPTION
## Summary

Fixes two MCP stdio / tool-schema issues reported by users:

- **#154** — `dotenv` v17 logs informational messages to stdout when no `.env` is present, which breaks JSON-RPC on stdio transports. Load env with `dotenv.config({ quiet: true })` in `src/env.ts` before validating `process.env`.
- **#144** — `createCollectionRequest` / `updateCollectionRequest` declared `events` as `.nullable().optional()`, which produced a JSON Schema `anyOf` (`array` | `null`) instead of a top-level `type: array`. MCP clients then serialized `events` as a string. Align with `headerData` by using `.optional()` only.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm test` — new unit tests in `src/tests/env.test.ts` (12 passed); integration tests require a real `POSTMAN_API_KEY`
- [ ] Start local stdio server in Claude Code / Cursor without a `.env` file — no dotenv banner on stdout
- [ ] Call `createCollectionRequest` with an `events` array — scripts accepted (not `Expected array, received string`)

Closes #154
Closes #144
