### PR TITLE
fix: merge request events by listen in updateCollectionRequest

### DIFF
--- a/dist/src/tools/updateCollectionRequest.js
+++ b/dist/src/tools/updateCollectionRequest.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ContentType } from '../clients/postman.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
+import { extractRequestEvents, mergeEventsByListen } from './utils/mergeRequestEvents.js';
 export const method = 'updateCollectionRequest';
 export const description = 'Updates a request in a collection. For a complete list of properties, refer to the **Request** entry in the [Postman Collection Format documentation](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html).\n\n**Note:**\n\n- You must pass a collection ID (\\`12ece9e1-2abf-4edc-8e34-de66e74114d2\\`), not a collection(\\`12345678-12ece9e1-2abf-4edc-8e34-de66e74114d2\\`), in this endpoint.\n- This endpoint does not support changing the folder of a request.\n- This endpoint acts like a PATCH method. It only updates the values that you pass in the request body.';
 export const parameters = z.object({
@@ -331,7 +332,7 @@ export const parameters = z.object({
             .optional(),
     }))
         .nullable()
-        .describe('A list of scripts configured to run when specific events occur.')
+        .describe('Scripts to add or update, merged by `listen` (`prerequest`, `test`). Existing event types not listed here are preserved (unlike a raw PUT that replaces the whole array).')
         .optional(),
 });
 export const annotations = {
@@ -370,8 +371,12 @@ export async function handler(args, extra) {
             bodyPayload.dataOptions = args.dataOptions;
         if (args.auth !== undefined)
             bodyPayload.auth = args.auth;
-        if (args.events !== undefined)
-            bodyPayload.events = args.events;
+        if (args.events != null) {
+            const getOptions = { headers: extra.headers };
+            const current = await extra.client.get(url, getOptions);
+            const existing = extractRequestEvents(current);
+            bodyPayload.events = mergeEventsByListen(existing, args.events);
+        }
         const options = {
             body: JSON.stringify(bodyPayload),
             contentType: ContentType.Json,

--- a/dist/src/tools/utils/mergeRequestEvents.js
+++ b/dist/src/tools/utils/mergeRequestEvents.js
@@ -1,0 +1,36 @@
+export function mergeEventsByListen(existing, incoming) {
+    const prior = existing ?? [];
+    const byListen = new Map();
+    for (const event of prior) {
+        if (event?.listen)
+            byListen.set(event.listen, event);
+    }
+    for (const event of incoming) {
+        if (event?.listen)
+            byListen.set(event.listen, event);
+    }
+    const order = [];
+    for (const event of prior) {
+        if (event?.listen && !order.includes(event.listen))
+            order.push(event.listen);
+    }
+    for (const event of incoming) {
+        if (event?.listen && !order.includes(event.listen))
+            order.push(event.listen);
+    }
+    return order.map((listen) => byListen.get(listen));
+}
+export function extractRequestEvents(payload) {
+    if (!payload || typeof payload !== 'object')
+        return [];
+    const root = payload;
+    if (Array.isArray(root.events))
+        return root.events;
+    const data = root.data;
+    if (data && typeof data === 'object') {
+        const events = data.events;
+        if (Array.isArray(events))
+            return events;
+    }
+    return [];
+}

--- a/src/tests/mergeRequestEvents.test.ts
+++ b/src/tests/mergeRequestEvents.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { extractRequestEvents, mergeEventsByListen } from '../tools/utils/mergeRequestEvents.js';
+
+describe('mergeEventsByListen', () => {
+  it('replaces only the listen type present in incoming events', () => {
+    const existing = [
+      { listen: 'prerequest', script: { exec: ['// auth'] } },
+      { listen: 'test', script: { exec: ['pm.test("old", () => {})'] } },
+    ];
+    const incoming = [{ listen: 'test', script: { exec: ['pm.test("new", () => {})'] } }];
+    const merged = mergeEventsByListen(existing, incoming);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].listen).toBe('prerequest');
+    expect(merged[1].script).toEqual({ exec: ['pm.test("new", () => {})'] });
+  });
+
+  it('appends a new listen type from incoming', () => {
+    const existing = [{ listen: 'test', script: { exec: ['a'] } }];
+    const incoming = [{ listen: 'prerequest', script: { exec: ['b'] } }];
+    const merged = mergeEventsByListen(existing, incoming);
+    expect(merged.map((e) => e.listen)).toEqual(['test', 'prerequest']);
+  });
+
+  it('returns incoming when there are no existing events', () => {
+    const incoming = [{ listen: 'test', script: { exec: ['x'] } }];
+    expect(mergeEventsByListen(undefined, incoming)).toEqual(incoming);
+  });
+});
+
+describe('extractRequestEvents', () => {
+  it('reads events from top-level response', () => {
+    const payload = { events: [{ listen: 'test' }] };
+    expect(extractRequestEvents(payload)).toEqual([{ listen: 'test' }]);
+  });
+
+  it('reads events from data wrapper', () => {
+    const payload = { data: { events: [{ listen: 'prerequest' }] } };
+    expect(extractRequestEvents(payload)).toEqual([{ listen: 'prerequest' }]);
+  });
+});

--- a/src/tools/updateCollectionRequest.ts
+++ b/src/tools/updateCollectionRequest.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { PostmanAPIClient, ContentType } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
+import { extractRequestEvents, mergeEventsByListen } from './utils/mergeRequestEvents.js';
 
 export const method = 'updateCollectionRequest';
 export const description =
@@ -399,7 +400,9 @@ export const parameters = z.object({
       })
     )
     .nullable()
-    .describe('A list of scripts configured to run when specific events occur.')
+    .describe(
+      'Scripts to add or update, merged by `listen` (`prerequest`, `test`). Existing event types not listed here are preserved (unlike a raw PUT that replaces the whole array).'
+    )
     .optional(),
 });
 export const annotations = {
@@ -431,7 +434,12 @@ export async function handler(
     if (args.graphqlModeData !== undefined) bodyPayload.graphqlModeData = args.graphqlModeData;
     if (args.dataOptions !== undefined) bodyPayload.dataOptions = args.dataOptions;
     if (args.auth !== undefined) bodyPayload.auth = args.auth;
-    if (args.events !== undefined) bodyPayload.events = args.events;
+    if (args.events != null) {
+      const getOptions: any = { headers: extra.headers };
+      const current = await extra.client.get(url, getOptions);
+      const existing = extractRequestEvents(current);
+      bodyPayload.events = mergeEventsByListen(existing, args.events);
+    }
     const options: any = {
       body: JSON.stringify(bodyPayload),
       contentType: ContentType.Json,

--- a/src/tools/utils/mergeRequestEvents.ts
+++ b/src/tools/utils/mergeRequestEvents.ts
@@ -1,0 +1,48 @@
+export type RequestEvent = {
+  listen?: string;
+  script?: unknown;
+  [key: string]: unknown;
+};
+
+/**
+ * Merge incoming request events by `listen` (prerequest / test), preserving
+ * event types not included in the update. Matches Postman Collection v2.1
+ * event semantics and fixes wholesale replacement when agents update one script.
+ */
+export function mergeEventsByListen(
+  existing: RequestEvent[] | undefined | null,
+  incoming: RequestEvent[]
+): RequestEvent[] {
+  const prior = existing ?? [];
+  const byListen = new Map<string, RequestEvent>();
+
+  for (const event of prior) {
+    if (event?.listen) byListen.set(event.listen, event);
+  }
+  for (const event of incoming) {
+    if (event?.listen) byListen.set(event.listen, event);
+  }
+
+  const order: string[] = [];
+  for (const event of prior) {
+    if (event?.listen && !order.includes(event.listen)) order.push(event.listen);
+  }
+  for (const event of incoming) {
+    if (event?.listen && !order.includes(event.listen)) order.push(event.listen);
+  }
+
+  return order.map((listen) => byListen.get(listen)!);
+}
+
+/** Pull events from a Postman GET /collections/{id}/requests/{id} response. */
+export function extractRequestEvents(payload: unknown): RequestEvent[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const root = payload as Record<string, unknown>;
+  if (Array.isArray(root.events)) return root.events as RequestEvent[];
+  const data = root.data;
+  if (data && typeof data === 'object') {
+    const events = (data as Record<string, unknown>).events;
+    if (Array.isArray(events)) return events as RequestEvent[];
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

When `updateCollectionRequest` receives `events`, the handler now GETs the current request and **merges by `listen`** (`prerequest` / `test`) instead of replacing the whole array. Updating only the test script no longer deletes an existing prerequest script.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm test -- src/tests/mergeRequestEvents.test.ts`
- [ ] Update a request with both scripts via MCP; pass only `test` in `events` — prerequest preserved

Closes #150
