### PR TITLE
fix: runCollection stability and putCollection noauth

### DIFF
--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -250,9 +250,18 @@ async function run() {
     const toolsetName = useCode ? 'code' : useFull ? 'full' : 'minimal';
     logBoth(server, 'info', `Server connected and ready: ${SERVER_NAME}@${APP_VERSION} with ${tools.length} tools (${toolsetName})`);
 }
-run().catch((error) => {
-    log('error', 'Unhandled error during server execution', {
+function fatalStartupError(label, error) {
+    log('error', label, {
         error: String(error?.message || error),
     });
     process.exit(1);
+}
+process.on('unhandledRejection', (reason) => {
+    fatalStartupError('Unhandled promise rejection', reason);
+});
+process.on('uncaughtException', (error) => {
+    fatalStartupError('Uncaught exception', error);
+});
+run().catch((error) => {
+    fatalStartupError('Unhandled error during server execution', error);
 });

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -90,6 +90,7 @@ async function loadAllTools() {
     return tools;
 }
 let clientInfo = undefined;
+let serverReady = false;
 async function run() {
     const args = process.argv.slice(2);
     const useFull = args.includes('--full');
@@ -249,6 +250,7 @@ async function run() {
     await server.connect(transport);
     const toolsetName = useCode ? 'code' : useFull ? 'full' : 'minimal';
     logBoth(server, 'info', `Server connected and ready: ${SERVER_NAME}@${APP_VERSION} with ${tools.length} tools (${toolsetName})`);
+    serverReady = true;
 }
 function fatalStartupError(label, error) {
     log('error', label, {
@@ -257,7 +259,12 @@ function fatalStartupError(label, error) {
     process.exit(1);
 }
 process.on('unhandledRejection', (reason) => {
-    fatalStartupError('Unhandled promise rejection', reason);
+    log('error', 'Unhandled promise rejection', {
+        error: String(reason?.message || reason),
+    });
+    if (!serverReady) {
+        process.exit(1);
+    }
 });
 process.on('uncaughtException', (error) => {
     fatalStartupError('Uncaught exception', error);

--- a/dist/src/tools/putCollection.js
+++ b/dist/src/tools/putCollection.js
@@ -767,6 +767,7 @@ export const parameters = z.object({
             .object({
             type: z
                 .enum([
+                'noauth',
                 'basic',
                 'bearer',
                 'apikey',
@@ -781,6 +782,7 @@ export const parameters = z.object({
                 'asap',
             ])
                 .describe('The authorization type.'),
+            noauth: z.unknown().optional(),
             apikey: z
                 .array(z
                 .object({

--- a/dist/src/tools/runner/executor.js
+++ b/dist/src/tools/runner/executor.js
@@ -111,8 +111,15 @@ export async function executeCollection(context) {
 }
 function runNewman(options, tracker, output) {
     return new Promise((resolve, reject) => {
-        newman
-            .run(options)
+        let run;
+        try {
+            run = newman.run(options);
+        }
+        catch (error) {
+            reject(error);
+            return;
+        }
+        run
             .on('start', () => {
             output.add('🎯 Starting collection run...\n');
         })

--- a/dist/src/tools/runner/executor.js
+++ b/dist/src/tools/runner/executor.js
@@ -73,7 +73,13 @@ export function buildNewmanOptions(params, collection, environment) {
         delayRequest: 1000,
         ignoreRedirects: false,
         insecure: false,
-        bail: params.stopOnFailure ? ['failure'] : false,
+        bail: params.stopOnFailure
+            ? ['failure']
+            : params.stopOnError || params.abortOnError
+                ? true
+                : params.abortOnFailure
+                    ? ['failure']
+                    : false,
         suppressExitCode: true,
         reporters: [],
         reporter: {},
@@ -128,6 +134,10 @@ function runNewman(options, tracker, output) {
                     output.add(testResults);
                 }
             }
+        })
+            .on('exception', (_err, args) => {
+            const msg = args?.error?.message ?? String(args?.error ?? 'unknown');
+            output.add('\n❌ Runtime exception: ' + msg);
         })
             .on('done', (err, summary) => {
             if (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,9 +363,21 @@ async function run() {
   );
 }
 
-run().catch((error: unknown) => {
-  log('error', 'Unhandled error during server execution', {
+function fatalStartupError(label: string, error: unknown) {
+  log('error', label, {
     error: String((error as any)?.message || error),
   });
   process.exit(1);
+}
+
+process.on('unhandledRejection', (reason) => {
+  fatalStartupError('Unhandled promise rejection', reason);
+});
+
+process.on('uncaughtException', (error) => {
+  fatalStartupError('Uncaught exception', error);
+});
+
+run().catch((error: unknown) => {
+  fatalStartupError('Unhandled error during server execution', error);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,8 @@ async function loadAllTools(): Promise<ToolModule[]> {
 
 let clientInfo: InitializeRequest['params']['clientInfo'] | undefined = undefined;
 
+let serverReady = false;
+
 async function run() {
   const args = process.argv.slice(2);
   const useFull = args.includes('--full');
@@ -361,6 +363,7 @@ async function run() {
     'info',
     `Server connected and ready: ${SERVER_NAME}@${APP_VERSION} with ${tools.length} tools (${toolsetName})`
   );
+  serverReady = true;
 }
 
 function fatalStartupError(label: string, error: unknown) {
@@ -371,7 +374,12 @@ function fatalStartupError(label: string, error: unknown) {
 }
 
 process.on('unhandledRejection', (reason) => {
-  fatalStartupError('Unhandled promise rejection', reason);
+  log('error', 'Unhandled promise rejection', {
+    error: String((reason as any)?.message || reason),
+  });
+  if (!serverReady) {
+    process.exit(1);
+  }
 });
 
 process.on('uncaughtException', (error) => {

--- a/src/tests/setupEnv.ts
+++ b/src/tests/setupEnv.ts
@@ -1,0 +1,3 @@
+if (!process.env.POSTMAN_API_KEY) {
+  process.env.POSTMAN_API_KEY = 'PMAK-test-integration-key';
+}

--- a/src/tests/unit/executor.test.ts
+++ b/src/tests/unit/executor.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildNewmanOptions } from '../../tools/runner/executor.js';
+
+describe('buildNewmanOptions', () => {
+  const baseParams = { collectionId: '12345-33823532ab9e41c9b6fd12d0fd459b8b' };
+  const collection = { item: [] };
+
+  it('maps stopOnFailure to bail failure array', () => {
+    const opts = buildNewmanOptions({ ...baseParams, stopOnFailure: true }, collection);
+    expect(opts.bail).toEqual(['failure']);
+  });
+
+  it('maps stopOnError to bail true', () => {
+    const opts = buildNewmanOptions({ ...baseParams, stopOnError: true }, collection);
+    expect(opts.bail).toBe(true);
+  });
+
+  it('maps abortOnError to bail true', () => {
+    const opts = buildNewmanOptions({ ...baseParams, abortOnError: true }, collection);
+    expect(opts.bail).toBe(true);
+  });
+
+  it('maps abortOnFailure to bail failure array when no higher-priority flags are set', () => {
+    const opts = buildNewmanOptions({ ...baseParams, abortOnFailure: true }, collection);
+    expect(opts.bail).toEqual(['failure']);
+  });
+
+  it('defaults bail to false', () => {
+    const opts = buildNewmanOptions(baseParams, collection);
+    expect(opts.bail).toBe(false);
+  });
+
+  it('prefers stopOnFailure over stopOnError', () => {
+    const opts = buildNewmanOptions(
+      { ...baseParams, stopOnFailure: true, stopOnError: true },
+      collection
+    );
+    expect(opts.bail).toEqual(['failure']);
+  });
+});

--- a/src/tests/unit/putCollectionAuth.test.ts
+++ b/src/tests/unit/putCollectionAuth.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parameters } from '../../tools/putCollection.js';
+
+describe('putCollection auth schema', () => {
+  const basePayload = {
+    collectionId: '12345-33823532ab9e41c9b6fd12d0fd459b8b',
+    collection: {
+      info: {
+        name: 'Test Collection',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [],
+    },
+  };
+
+  it('accepts collection-level noauth auth type', () => {
+    const result = parameters.safeParse({
+      ...basePayload,
+      collection: {
+        ...basePayload.collection,
+        auth: { type: 'noauth', noauth: {} },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown auth types at collection level', () => {
+    const result = parameters.safeParse({
+      ...basePayload,
+      collection: {
+        ...basePayload.collection,
+        auth: { type: 'invalid-auth' },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -953,6 +953,7 @@ export const parameters = z.object({
         .object({
           type: z
             .enum([
+              'noauth',
               'basic',
               'bearer',
               'apikey',
@@ -967,6 +968,7 @@ export const parameters = z.object({
               'asap',
             ])
             .describe('The authorization type.'),
+          noauth: z.unknown().optional(),
           apikey: z
             .array(
               z

--- a/src/tools/runner/executor.ts
+++ b/src/tools/runner/executor.ts
@@ -149,8 +149,15 @@ export async function executeCollection(context: ExecutionContext): Promise<Exec
 
 function runNewman(options: any, tracker: TestTracker, output: OutputBuilder): Promise<any> {
   return new Promise((resolve, reject) => {
-    newman
-      .run(options)
+    let run: ReturnType<typeof newman.run>;
+    try {
+      run = newman.run(options);
+    } catch (error: any) {
+      reject(error);
+      return;
+    }
+
+    run
       .on('start', () => {
         output.add('🎯 Starting collection run...\n');
       })

--- a/src/tools/runner/executor.ts
+++ b/src/tools/runner/executor.ts
@@ -99,7 +99,13 @@ export function buildNewmanOptions(
     delayRequest: 1000,
     ignoreRedirects: false,
     insecure: false,
-    bail: params.stopOnFailure ? ['failure'] : false,
+    bail: params.stopOnFailure
+      ? ['failure']
+      : params.stopOnError || params.abortOnError
+        ? true
+        : params.abortOnFailure
+          ? ['failure']
+          : false,
     suppressExitCode: true,
     reporters: [],
     reporter: {},
@@ -166,6 +172,10 @@ function runNewman(options: any, tracker: TestTracker, output: OutputBuilder): P
             output.add(testResults);
           }
         }
+      })
+      .on('exception', (_err: any, args: any) => {
+        const msg = args?.error?.message ?? String(args?.error ?? 'unknown');
+        output.add('\n❌ Runtime exception: ' + msg);
       })
       .on('done', (err: any, summary: any) => {
         if (err) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     include: ['src/tests/**/*.test.ts'],
     globals: true,
-    setupFiles: [],
+    setupFiles: ['src/tests/setupEnv.ts'],
     testTimeout: 180000, // 2 minutes
     hookTimeout: 180000, // 1 minute for hooks (beforeAll, afterAll)
     teardownTimeout: 180000, // 100 seconds for cleanup


### PR DESCRIPTION
## Summary

- Harden stdio server: `unhandledRejection` / `uncaughtException` handlers
- Newman: `exception` listener; wire `stopOnError` / `abortOnError` to bail
- `putCollection`: add `noauth` to collection-level auth (parity with createCollection)

Addresses #107; partial #142 (full folder union schema still open)

## Test plan

- [x] `pnpm run build`
