### PR TITLE
docs: add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ Be respectful and constructive. We want this to be a welcoming project for contr
 
 ## Ways to contribute
 
-- **Report a bug** — open an issue with clear reproduction steps, the toolset you ran (`--minimal` / `--full` / `--code`), your OS, and the MCP client (Claude Desktop, Cursor, Windsurf, etc.).
-- **Suggest an improvement** — open an issue describing the problem and the outcome you'd like. For changes to a tool's parameters or description, please file an issue first (see [Generated files](#generated-files-please-dont-hand-edit) below).
-- **Open a pull request** — for fixes, tests, or docs. For anything large, open an issue first so we can align before you invest the time.
+- **Report a bug** — Open an issue with clear reproduction steps, the toolset you ran (`--minimal` / `--full` / `--code`), your OS, and the MCP client (Claude Desktop, Cursor, Windsurf, etc.).
+- **Suggest an improvement** — Open an issue describing the problem and the outcome you'd like. For changes to a tool's parameters or description, please file an issue first (see [Generated files](#generated-files-please-dont-hand-edit) below).
+- **Open a pull request** — For fixes, tests, or docs. For anything large, open an issue first so we can align before you invest the time.
 
 ## Development setup
 
@@ -18,7 +18,7 @@ Be respectful and constructive. We want this to be a welcoming project for contr
 
 - Node.js `>= 20`
 - [pnpm](https://pnpm.io/) `10.6.2` (the repo enforces pnpm; npm/yarn are blocked by a `preinstall` hook)
-- A Postman API key — create one at https://go.postman.co/settings/me/api-keys
+- A Postman API key — Create one in [Postman](https://go.postman.co/settings/me/api-keys)
 
 **Get started**
 
@@ -37,7 +37,10 @@ pnpm lint         # eslint
 POSTMAN_API_KEY=<your-key> node dist/src/index.js --full
 ```
 
-Useful flags: `--minimal` / `--full` / `--code` select the toolset, `--region <us|eu>` sets the API region, and `--quiet` suppresses verbose startup logs (needed on Windows + Windsurf). See the [README](./README.md) for client configuration examples.
+Useful flags:
+- `--minimal` / `--full` / `--code` — Select the toolset.
+- `--region <us|eu>` — Sets the API region.
+- `--quiet` — Suppresses verbose startup logs (needed on Windows + Windsurf). See the [README](./README.md) for client configuration examples.
 
 ## Project layout
 
@@ -57,30 +60,30 @@ dist/                 # compiled output (generated — do not edit)
 
 ## Generated files (please don't hand-edit)
 
-Several files are **auto-generated from the Postman API OpenAPI specification** and are overwritten whenever the project is rebuilt. Editing them by hand looks like it works, but the change won't persist. Please don't modify:
+Several files are **auto-generated from the Postman API OpenAPI specification** and are overwritten whenever the project is rebuilt. Editing them by hand looks like it works, but the change won't persist. Don't modify the following:
 
-- `src/tools/*.ts` — the top-level generated tool files (schemas + descriptions)
-- `src/views/*.njk` at the root of `src/views/`
-- `dist/**` — compiled output
+- `src/tools/*.ts` — The top-level generated tool files (schemas and descriptions).
+- `src/views/*.njk` at the root of `src/views/`.
+- `dist/**` — The compiled output.
 
 **Spotted a wrong tool schema or description?** (e.g. a missing enum value, a parameter that should be optional, an unclear description.) That's a valuable report — please **open an issue** describing the desired change, or call it out in your PR description. We maintain those definitions at the source and will fold your suggestion in there.
 
 **Safe to edit** (PRs welcome directly):
 
-- `src/tools/getCollection/*`, `src/tools/runner/*` — hand-written orchestrators
-- `src/tools/utils/*` — shared helpers
-- `src/clients/*`, `src/constants.ts`, `src/enabledResources.ts`, `src/env.ts`, `src/index.ts`
-- `src/views/errors/*`, `src/resources/*`
-- `src/tests/**` — tests
-- Documentation
+- `src/tools/getCollection/*` and `src/tools/runner/*` — Hand-written orchestrators.
+- `src/tools/utils/*` — Shared helpers.
+- `src/clients/*`, `src/constants.ts`, `src/enabledResources.ts`, `src/env.ts`, and `src/index.ts`
+- `src/views/errors/*` and `src/resources/*`
+- `src/tests/**` — Tests.
+- Documentation.
 
-If you're unsure whether a file is generated, open an issue and ask — we're happy to point you to the right place.
+If you're unsure whether a file is generated, open an issue and ask. We're happy to point you to the right place.
 
 ## Pull request guidelines
 
-To keep review fast and merges clean, please:
+To keep review fast and merges clean:
 
-1. **One focused change per PR.** Don't bundle unrelated fixes — a PR that fixes a single bug (or closes a single issue) is far easier to review, merge, and revert if needed. If you have several fixes, open one PR each.
+1. **One focused change per PR.** Don't bundle unrelated fixes. A PR that fixes a single bug (or closes a single issue) is far easier to review, merge, and revert if needed. If you have several fixes, open one PR each.
 2. **Keep your branch current and conflict-free.** Branch off the latest `main` and rebase if `main` moves ahead. We can't merge a PR that conflicts with or is behind `main`.
 3. **Include tests** for any behavior change, and make sure the full suite passes.
 4. **Run the checks before pushing:**
@@ -88,15 +91,15 @@ To keep review fast and merges clean, please:
    pnpm build && pnpm test && pnpm lint
    ```
 5. **Use [Conventional Commits](https://www.conventionalcommits.org/)** for commit messages and the PR title (`fix:`, `feat:`, `docs:`, `test:`, `refactor:`, `chore:`).
-6. **Write a clear description** — what changed, why, and a link to the related issue (`Closes #123`).
+6. **Write a clear description**  for what you've changed, why, and link to the related issue (`Closes #123`).
 
 ## How pull requests are reviewed
 
-When you open a PR we evaluate it for security, correctness, and scope, and run the build/test/lint suite. Most well-scoped PRs against editable files merge quickly. If your change touches a generated file, we may not be able to merge it directly — but we'll take the underlying suggestion forward and credit your contribution.
+When you open a PR we'll review it for security, correctness, and scope, and run the build/test/lint suite. Most well-scoped PRs against editable files merge quickly. If your change touches a generated file, we may not be able to merge it directly, but we'll take the underlying suggestion forward and credit your contribution.
 
 ## Reporting a security issue
 
-**Please do not open a public issue for security vulnerabilities.** Report them privately to the Postman security team at https://www.postman.com/legal/security-policy/ (or use GitHub's "Report a vulnerability" under the Security tab). We'll coordinate a fix and disclosure with you.
+**Please don't open a public issue for security vulnerabilities.** Report them privately to the Postman security team at https://www.postman.com/legal/security-policy/ (or use GitHub's "Report a vulnerability" under the Security tab). We'll coordinate a fix and disclosure with you.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to the Postman MCP Server
+
+Thanks for your interest in contributing! This document explains how to set up the project, what to work on, and how to get a pull request merged smoothly. Contributions of all sizes are welcome — bug fixes, tests, documentation, and well-scoped features.
+
+## Code of conduct
+
+Be respectful and constructive. We want this to be a welcoming project for contributors of every background and experience level. Harassment or abusive behavior won't be tolerated.
+
+## Ways to contribute
+
+- **Report a bug** — open an issue with clear reproduction steps, the toolset you ran (`--minimal` / `--full` / `--code`), your OS, and the MCP client (Claude Desktop, Cursor, Windsurf, etc.).
+- **Suggest an improvement** — open an issue describing the problem and the outcome you'd like. For changes to a tool's parameters or description, please file an issue first (see [Generated files](#generated-files-please-dont-hand-edit) below).
+- **Open a pull request** — for fixes, tests, or docs. For anything large, open an issue first so we can align before you invest the time.
+
+## Development setup
+
+**Prerequisites**
+
+- Node.js `>= 20`
+- [pnpm](https://pnpm.io/) `10.6.2` (the repo enforces pnpm; npm/yarn are blocked by a `preinstall` hook)
+- A Postman API key — create one at https://go.postman.co/settings/me/api-keys
+
+**Get started**
+
+```bash
+git clone https://github.com/postmanlabs/postman-mcp-server.git
+cd postman-mcp-server
+pnpm install
+pnpm build        # eslint --fix, prettier, tsc
+pnpm test         # vitest
+pnpm lint         # eslint
+```
+
+**Run the server locally (STDIO)**
+
+```bash
+POSTMAN_API_KEY=<your-key> node dist/src/index.js --full
+```
+
+Useful flags: `--minimal` / `--full` / `--code` select the toolset, `--region <us|eu>` sets the API region, and `--quiet` suppresses verbose startup logs (needed on Windows + Windsurf). See the [README](./README.md) for client configuration examples.
+
+## Project layout
+
+```
+src/
+  index.ts            # STDIO server entrypoint
+  tools/              # MCP tools (most are generated — see below)
+    getCollection/    # hand-written orchestrators (safe to edit)
+    runner/           # collection runner (safe to edit)
+    utils/            # tool helpers (safe to edit)
+  clients/            # Postman API client
+  resources/          # bundled instructions/resources
+  views/              # response templates
+  tests/              # unit + integration tests
+dist/                 # compiled output (generated — do not edit)
+```
+
+## Generated files (please don't hand-edit)
+
+Several files are **auto-generated from the Postman API OpenAPI specification** and are overwritten whenever the project is rebuilt. Editing them by hand looks like it works, but the change won't persist. Please don't modify:
+
+- `src/tools/*.ts` — the top-level generated tool files (schemas + descriptions)
+- `src/views/*.njk` at the root of `src/views/`
+- `dist/**` — compiled output
+
+**Spotted a wrong tool schema or description?** (e.g. a missing enum value, a parameter that should be optional, an unclear description.) That's a valuable report — please **open an issue** describing the desired change, or call it out in your PR description. We maintain those definitions at the source and will fold your suggestion in there.
+
+**Safe to edit** (PRs welcome directly):
+
+- `src/tools/getCollection/*`, `src/tools/runner/*` — hand-written orchestrators
+- `src/tools/utils/*` — shared helpers
+- `src/clients/*`, `src/constants.ts`, `src/enabledResources.ts`, `src/env.ts`, `src/index.ts`
+- `src/views/errors/*`, `src/resources/*`
+- `src/tests/**` — tests
+- Documentation
+
+If you're unsure whether a file is generated, open an issue and ask — we're happy to point you to the right place.
+
+## Pull request guidelines
+
+To keep review fast and merges clean, please:
+
+1. **One focused change per PR.** Don't bundle unrelated fixes — a PR that fixes a single bug (or closes a single issue) is far easier to review, merge, and revert if needed. If you have several fixes, open one PR each.
+2. **Keep your branch current and conflict-free.** Branch off the latest `main` and rebase if `main` moves ahead. We can't merge a PR that conflicts with or is behind `main`.
+3. **Include tests** for any behavior change, and make sure the full suite passes.
+4. **Run the checks before pushing:**
+   ```bash
+   pnpm build && pnpm test && pnpm lint
+   ```
+5. **Use [Conventional Commits](https://www.conventionalcommits.org/)** for commit messages and the PR title (`fix:`, `feat:`, `docs:`, `test:`, `refactor:`, `chore:`).
+6. **Write a clear description** — what changed, why, and a link to the related issue (`Closes #123`).
+
+## How pull requests are reviewed
+
+When you open a PR we evaluate it for security, correctness, and scope, and run the build/test/lint suite. Most well-scoped PRs against editable files merge quickly. If your change touches a generated file, we may not be able to merge it directly — but we'll take the underlying suggestion forward and credit your contribution.
+
+## Reporting a security issue
+
+**Please do not open a public issue for security vulnerabilities.** Report them privately to the Postman security team at https://www.postman.com/legal/security-policy/ (or use GitHub's "Report a vulnerability" under the Security tab). We'll coordinate a fix and disclosure with you.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as this project (see [LICENSE](./LICENSE)).


### PR DESCRIPTION
## Summary

Adds a `CONTRIBUTING.md` for external contributors — the repo had none.

Covers:
- Development setup (Node ≥20, pnpm, build/test/lint, running the STDIO server with a Postman API key)
- Project layout and which files are safe to edit
- A clear heads-up that the top-level `src/tools/*.ts`, root `src/views/*.njk`, and `dist/**` are auto-generated and shouldn't be hand-edited — with guidance to file an issue for tool schema/description changes instead
- PR guidelines that keep review fast: one focused change per PR, keep branches conflict-free with `main`, include tests, run `pnpm build && pnpm test && pnpm lint`, Conventional Commits
- How PRs are reviewed, security-issue reporting, and licensing

## Notes

- Documentation only — no code changes.
- Links to the existing `README.md` for client configuration rather than duplicating it.

Generated with [Claude Code](https://claude.com/claude-code)