### PR TITLE
fix: nested collection folders in createCollection/putCollection

### DIFF
--- a/dist/src/tools/createCollection.js
+++ b/dist/src/tools/createCollection.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ContentType } from '../clients/postman.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
+import { sanitizeCollectionPayload } from './utils/collectionItems.js';
 export const method = 'createCollection';
 export const description = 'Creates a collection using the [Postman Collection v2.1.0 schema format](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html).\n\n**Note:**\n\nIf you do not include the \\`workspace\\` query parameter, the system creates the collection in the oldest personal Internal workspace you own.\n';
 export const parameters = z.object({
@@ -946,8 +947,9 @@ export async function handler(args, extra) {
             query.set('workspace', String(args.workspace));
         const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
         const bodyPayload = {};
-        if (args.collection !== undefined)
-            bodyPayload.collection = args.collection;
+        if (args.collection !== undefined) {
+            bodyPayload.collection = sanitizeCollectionPayload(args.collection);
+        }
         const options = {
             body: JSON.stringify(bodyPayload),
             contentType: ContentType.Json,

--- a/dist/src/tools/putCollection.js
+++ b/dist/src/tools/putCollection.js
@@ -771,6 +771,7 @@ export const parameters = z.object({
             .object({
             type: z
                 .enum([
+                'noauth',
                 'basic',
                 'bearer',
                 'apikey',
@@ -785,6 +786,7 @@ export const parameters = z.object({
                 'asap',
             ])
                 .describe('The authorization type.'),
+            noauth: z.unknown().optional(),
             apikey: z
                 .array(z
                 .object({

--- a/dist/src/tools/putCollection.js
+++ b/dist/src/tools/putCollection.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ContentType } from '../clients/postman.js';
 import { asMcpError, McpError } from './utils/toolHelpers.js';
+import { sanitizeCollectionPayload } from './utils/collectionItems.js';
 export const method = 'putCollection';
 export const description = "Replaces the contents of a collection using the [Postman Collection v2.1.0 schema format](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html). Include the collection's ID values in the request body. If you do not, the endpoint removes the existing items and creates new items.\n\n- To perform an update asynchronously, use the \\`Prefer\\` header with the \\`respond-async\\` value. When performing an async update, this endpoint returns a HTTP \\`202 Accepted\\` response.\n- For a complete list of properties and information, see the [Postman Collection Format documentation](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html).\n- For protocol profile behavior, refer to Postman's [Protocol Profile Behavior documentation](https://github.com/postmanlabs/postman-runtime/blob/develop/docs/protocol-profile-behavior.md).\n\n**Note:**\n\n- The maximum collection size this endpoint accepts cannot exceed 100 MB.\n- Use the GET \\`/collection-updates-tasks/{taskId}\\` endpoint to get the collection's update status when performing an asynchronous update.\n- If you don't include the collection items' ID values from the request body, the endpoint **removes** the existing items and recreates the items with new ID values.\n- To copy another collection's contents to the given collection, remove all ID values before you pass it in this endpoint. If you do not, this endpoint returns an error. These values include the \\`id\\`, \\`uid\\`, and \\`postman_id\\` values.\n";
 export const parameters = z.object({
@@ -43,7 +44,10 @@ export const parameters = z.object({
             .describe('Information about the collection.'),
         item: z.array(z
             .object({
-            id: z.string().describe("The collection item's ID."),
+            id: z
+                .string()
+                .describe("The collection item's ID. Required for existing items when replacing a collection; omit for new folder/request items.")
+                .optional(),
             name: z.string().describe("The item's name.").optional(),
             description: z.string().nullable().describe("The item's description.").optional(),
             variable: z
@@ -1057,8 +1061,9 @@ export async function handler(args, extra) {
         const query = new URLSearchParams();
         const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
         const bodyPayload = {};
-        if (args.collection !== undefined)
-            bodyPayload.collection = args.collection;
+        if (args.collection !== undefined) {
+            bodyPayload.collection = sanitizeCollectionPayload(args.collection);
+        }
         const options = {
             body: JSON.stringify(bodyPayload),
             contentType: ContentType.Json,

--- a/dist/src/tools/utils/collectionItems.js
+++ b/dist/src/tools/utils/collectionItems.js
@@ -1,0 +1,21 @@
+export function sanitizeCollectionItems(items) {
+    if (!items)
+        return items;
+    return items.map(sanitizeCollectionItem);
+}
+function sanitizeCollectionItem(item) {
+    if (Array.isArray(item.item) && item.item.length > 0) {
+        const { request: _removed, ...folder } = item;
+        return { ...folder, item: item.item.map(sanitizeCollectionItem) };
+    }
+    if (item.request !== undefined) {
+        const { item: _nested, ...requestItem } = item;
+        return requestItem;
+    }
+    return item;
+}
+export function sanitizeCollectionPayload(collection) {
+    if (!collection?.item)
+        return collection;
+    return { ...collection, item: sanitizeCollectionItems(collection.item) };
+}

--- a/src/tests/integration/direct.test.ts
+++ b/src/tests/integration/direct.test.ts
@@ -753,6 +753,31 @@ describe('Postman MCP - Direct Integration Tests', () => {
       expect((verifyUpdateResult.content as any)[0].text).toContain(updatedName);
     });
 
+    it('should create a collection with nested folder items', async () => {
+      const workspace = WorkspaceDataFactory.createWorkspace({
+        name: '[Integration Test] Nested Folder Workspace',
+      });
+      const workspaceId = await createWorkspace(workspace);
+      createdWorkspaceIds.push(workspaceId);
+
+      const collectionData = CollectionDataFactory.createNestedFolderCollection();
+      const collectionId = await createCollection(collectionData, workspaceId);
+      createdCollectionIds.push(collectionId);
+
+      const getResult = await client.callTool(
+        {
+          name: 'getCollection',
+          arguments: { collectionId, model: 'full' },
+        },
+        undefined,
+        { timeout: 100000 }
+      );
+      expect(CollectionDataFactory.validateResponse(getResult)).toBe(true);
+      const responseText = (getResult.content as any)[0].text;
+      expect(responseText).toContain('API');
+      expect(responseText).toContain('Echo GET');
+    });
+
     it('should create and delete a minimal collection', async () => {
       const workspace = WorkspaceDataFactory.createWorkspace({
         name: '[Integration Test] Minimal Collection Workspace',

--- a/src/tests/integration/factories/dataFactory.ts
+++ b/src/tests/integration/factories/dataFactory.ts
@@ -253,7 +253,9 @@ export class CollectionDataFactory extends TestDataFactory {
     };
   }
 
-  public static createNestedFolderCollection(overrides: Partial<TestCollection> = {}): TestCollection {
+  public static createNestedFolderCollection(
+    overrides: Partial<TestCollection> = {}
+  ): TestCollection {
     return {
       info: {
         name: '[Integration Test] Nested Folder Collection',

--- a/src/tests/integration/factories/dataFactory.ts
+++ b/src/tests/integration/factories/dataFactory.ts
@@ -209,24 +209,27 @@ export class SpecDataFactory extends TestDataFactory {
   }
 }
 
+export interface TestCollectionItem {
+  name: string;
+  request?: {
+    url?: string;
+    method?: string;
+    header?: Array<{ key: string; value: string }>;
+    body?: {
+      mode?: string;
+      raw?: string;
+    };
+  };
+  item?: TestCollectionItem[];
+}
+
 export interface TestCollection {
   info: {
     name: string;
     description?: string;
     schema: string;
   };
-  item: Array<{
-    name: string;
-    request?: {
-      url?: string;
-      method?: string;
-      header?: Array<{ key: string; value: string }>;
-      body?: {
-        mode?: string;
-        raw?: string;
-      };
-    };
-  }>;
+  item: TestCollectionItem[];
 }
 
 export class CollectionDataFactory extends TestDataFactory {
@@ -244,6 +247,31 @@ export class CollectionDataFactory extends TestDataFactory {
             url: 'https://postman-echo.com/get',
             method: 'GET',
           },
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  public static createNestedFolderCollection(overrides: Partial<TestCollection> = {}): TestCollection {
+    return {
+      info: {
+        name: '[Integration Test] Nested Folder Collection',
+        description: 'Collection with nested folder items',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [
+        {
+          name: 'API',
+          item: [
+            {
+              name: 'Echo GET',
+              request: {
+                url: 'https://postman-echo.com/get',
+                method: 'GET',
+              },
+            },
+          ],
         },
       ],
       ...overrides,

--- a/src/tests/setupEnv.ts
+++ b/src/tests/setupEnv.ts
@@ -1,0 +1,1 @@
+process.env.POSTMAN_API_KEY ??= 'test-key';

--- a/src/tests/unit/collectionItems.test.ts
+++ b/src/tests/unit/collectionItems.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeCollectionItems } from '../../tools/utils/collectionItems.js';
+
+describe('sanitizeCollectionItems', () => {
+  it('removes request from folder nodes', () => {
+    const items = [
+      {
+        name: 'Folder',
+        request: {},
+        item: [{ name: 'GET', request: { method: 'GET', url: 'https://example.com' } }],
+      },
+    ];
+    const out = sanitizeCollectionItems(items)!;
+    expect(out[0]).not.toHaveProperty('request');
+    expect(out[0].item).toHaveLength(1);
+    expect(out[0].item![0]).not.toHaveProperty('item');
+    expect(out[0].item![0].request).toEqual({ method: 'GET', url: 'https://example.com' });
+  });
+
+  it('removes item from request leaves', () => {
+    const items = [
+      {
+        name: 'Req',
+        request: { method: 'POST', url: 'https://api.example.com' },
+        item: [],
+      },
+    ];
+    const out = sanitizeCollectionItems(items)!;
+    expect(out[0]).not.toHaveProperty('item');
+  });
+
+  it('sanitizes deeply nested folder structures', () => {
+    const items = [
+      {
+        name: 'Root',
+        request: {},
+        item: [
+          {
+            name: 'Child Folder',
+            request: {},
+            item: [
+              {
+                name: 'Leaf',
+                request: { method: 'GET', url: 'https://example.com' },
+                item: [],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const out = sanitizeCollectionItems(items)!;
+    expect(out[0]).not.toHaveProperty('request');
+    expect(out[0].item![0]).not.toHaveProperty('request');
+    expect(out[0].item![0].item![0]).not.toHaveProperty('item');
+  });
+});

--- a/src/tests/unit/collectionSchema.test.ts
+++ b/src/tests/unit/collectionSchema.test.ts
@@ -39,4 +39,12 @@ describe('collection tool schemas', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('putCollection accepts collection-level noauth', () => {
+    const result = putCollectionParameters.safeParse({
+      collectionId: 'collection-id',
+      collection: { ...folderCollection, auth: { type: 'noauth' } },
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/tests/unit/collectionSchema.test.ts
+++ b/src/tests/unit/collectionSchema.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parameters as createCollectionParameters } from '../../tools/createCollection.js';
+import { parameters as putCollectionParameters } from '../../tools/putCollection.js';
+
+const folderCollection = {
+  info: {
+    name: 'Test Collection',
+    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+  },
+  item: [
+    {
+      name: 'My Folder',
+      item: [
+        {
+          name: 'My Request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('collection tool schemas', () => {
+  it('createCollection accepts folder items without a request property', () => {
+    const result = createCollectionParameters.safeParse({
+      workspace: 'workspace-id',
+      collection: folderCollection,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('putCollection accepts folder items without a request property', () => {
+    const result = putCollectionParameters.safeParse({
+      collectionId: 'collection-id',
+      collection: folderCollection,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/tests/unit/createPutCollection.test.ts
+++ b/src/tests/unit/createPutCollection.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handler as createCollectionHandler } from '../../tools/createCollection.js';
+import { handler as putCollectionHandler } from '../../tools/putCollection.js';
+import type { PostmanAPIClient } from '../../clients/postman.js';
+
+const schema = 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json';
+
+function nestedCollectionPayload() {
+  return {
+    info: { name: 'Nested Test', schema },
+    item: [
+      {
+        name: 'Users',
+        request: {},
+        item: [
+          {
+            name: 'List Users',
+            request: { method: 'GET', url: 'https://api.example.com/users' },
+            item: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function mockClient(method: 'post' | 'put') {
+  const fn = vi.fn().mockResolvedValue({ collection: { id: 'owner-abc', uid: 'owner-abc' } });
+  return { [method]: fn, get: vi.fn(), patch: vi.fn(), delete: vi.fn() } as unknown as PostmanAPIClient & {
+    [K in typeof method]: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('createCollection / putCollection nested folders', () => {
+  it('createCollection sanitizes folder nodes before POST', async () => {
+    const client = mockClient('post');
+    await createCollectionHandler(
+      { workspace: 'ws-1', collection: nestedCollectionPayload() },
+      { client },
+    );
+
+    expect(client.post).toHaveBeenCalledOnce();
+    const body = JSON.parse((client.post.mock.calls[0] as [string, { body: string }])[1].body);
+    const folder = body.collection.item[0];
+    expect(folder).not.toHaveProperty('request');
+    expect(folder.item[0]).not.toHaveProperty('item');
+    expect(folder.item[0].request.method).toBe('GET');
+  });
+
+  it('putCollection sanitizes folder nodes before PUT', async () => {
+    const client = mockClient('put');
+    await putCollectionHandler(
+      {
+        collectionId: '12345-33823532ab9e41c9b6fd12d0fd459b8b',
+        collection: nestedCollectionPayload(),
+      },
+      { client },
+    );
+
+    expect(client.put).toHaveBeenCalledOnce();
+    const body = JSON.parse((client.put.mock.calls[0] as [string, { body: string }])[1].body);
+    const folder = body.collection.item[0];
+    expect(folder).not.toHaveProperty('request');
+    expect(folder.item[0].request.url).toBe('https://api.example.com/users');
+  });
+});

--- a/src/tests/unit/createPutCollection.test.ts
+++ b/src/tests/unit/createPutCollection.test.ts
@@ -26,7 +26,12 @@ function nestedCollectionPayload() {
 
 function mockClient(method: 'post' | 'put') {
   const fn = vi.fn().mockResolvedValue({ collection: { id: 'owner-abc', uid: 'owner-abc' } });
-  return { [method]: fn, get: vi.fn(), patch: vi.fn(), delete: vi.fn() } as unknown as PostmanAPIClient & {
+  return {
+    [method]: fn,
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as PostmanAPIClient & {
     [K in typeof method]: ReturnType<typeof vi.fn>;
   };
 }
@@ -36,7 +41,7 @@ describe('createCollection / putCollection nested folders', () => {
     const client = mockClient('post');
     await createCollectionHandler(
       { workspace: 'ws-1', collection: nestedCollectionPayload() },
-      { client },
+      { client }
     );
 
     expect(client.post).toHaveBeenCalledOnce();
@@ -54,7 +59,7 @@ describe('createCollection / putCollection nested folders', () => {
         collectionId: '12345-33823532ab9e41c9b6fd12d0fd459b8b',
         collection: nestedCollectionPayload(),
       },
-      { client },
+      { client }
     );
 
     expect(client.put).toHaveBeenCalledOnce();

--- a/src/tools/createCollection.ts
+++ b/src/tools/createCollection.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { PostmanAPIClient, ContentType } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
+import { sanitizeCollectionPayload } from './utils/collectionItems.js';
 
 export const method = 'createCollection';
 export const description =
@@ -1198,7 +1199,9 @@ export async function handler(
     if (args.workspace !== undefined) query.set('workspace', String(args.workspace));
     const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
     const bodyPayload: any = {};
-    if (args.collection !== undefined) bodyPayload.collection = args.collection;
+    if (args.collection !== undefined) {
+      bodyPayload.collection = sanitizeCollectionPayload(args.collection);
+    }
     const options: any = {
       body: JSON.stringify(bodyPayload),
       contentType: ContentType.Json,

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { PostmanAPIClient, ContentType } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
+import { sanitizeCollectionPayload } from './utils/collectionItems.js';
 
 export const method = 'putCollection';
 export const description =
@@ -53,7 +54,12 @@ export const parameters = z.object({
       item: z.array(
         z
           .object({
-            id: z.string().describe("The collection item's ID."),
+            id: z
+              .string()
+              .describe(
+                "The collection item's ID. Required for existing items when replacing a collection; omit for new folder/request items."
+              )
+              .optional(),
             name: z.string().describe("The item's name.").optional(),
             description: z.string().nullable().describe("The item's description.").optional(),
             variable: z
@@ -1336,7 +1342,9 @@ export async function handler(
     const query = new URLSearchParams();
     const url = query.toString() ? `${endpoint}?${query.toString()}` : endpoint;
     const bodyPayload: any = {};
-    if (args.collection !== undefined) bodyPayload.collection = args.collection;
+    if (args.collection !== undefined) {
+      bodyPayload.collection = sanitizeCollectionPayload(args.collection);
+    }
     const options: any = {
       body: JSON.stringify(bodyPayload),
       contentType: ContentType.Json,

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -959,6 +959,7 @@ export const parameters = z.object({
         .object({
           type: z
             .enum([
+              'noauth',
               'basic',
               'bearer',
               'apikey',
@@ -973,6 +974,7 @@ export const parameters = z.object({
               'asap',
             ])
             .describe('The authorization type.'),
+          noauth: z.unknown().optional(),
           apikey: z
             .array(
               z

--- a/src/tools/utils/collectionItems.ts
+++ b/src/tools/utils/collectionItems.ts
@@ -13,7 +13,7 @@ export type CollectionItemInput = {
  * Strips `request` from folder nodes and `item` from request leaves recursively.
  */
 export function sanitizeCollectionItems(
-  items: CollectionItemInput[] | undefined,
+  items: CollectionItemInput[] | undefined
 ): CollectionItemInput[] | undefined {
   if (!items) return items;
   return items.map(sanitizeCollectionItem);
@@ -32,7 +32,7 @@ function sanitizeCollectionItem(item: CollectionItemInput): CollectionItemInput 
 }
 
 export function sanitizeCollectionPayload<T extends { item?: CollectionItemInput[] }>(
-  collection: T,
+  collection: T
 ): T {
   if (!collection?.item) return collection;
   return { ...collection, item: sanitizeCollectionItems(collection.item) };

--- a/src/tools/utils/collectionItems.ts
+++ b/src/tools/utils/collectionItems.ts
@@ -1,0 +1,39 @@
+/** Postman collection v2.1 item: request leaf or folder (nested item array). */
+export type CollectionItemInput = {
+  name?: string;
+  description?: string | null;
+  id?: string;
+  request?: unknown;
+  item?: CollectionItemInput[];
+  [key: string]: unknown;
+};
+
+/**
+ * Normalize collection items for the Postman API oneOf (request XOR folder).
+ * Strips `request` from folder nodes and `item` from request leaves recursively.
+ */
+export function sanitizeCollectionItems(
+  items: CollectionItemInput[] | undefined,
+): CollectionItemInput[] | undefined {
+  if (!items) return items;
+  return items.map(sanitizeCollectionItem);
+}
+
+function sanitizeCollectionItem(item: CollectionItemInput): CollectionItemInput {
+  if (Array.isArray(item.item) && item.item.length > 0) {
+    const { request: _removed, ...folder } = item;
+    return { ...folder, item: item.item.map(sanitizeCollectionItem) };
+  }
+  if (item.request !== undefined) {
+    const { item: _nested, ...requestItem } = item;
+    return requestItem;
+  }
+  return item;
+}
+
+export function sanitizeCollectionPayload<T extends { item?: CollectionItemInput[] }>(
+  collection: T,
+): T {
+  if (!collection?.item) return collection;
+  return { ...collection, item: sanitizeCollectionItems(collection.item) };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  cacheDir: '/tmp/vitest-cache',
   test: {
     include: ['src/tests/**/*.test.ts'],
     globals: true,
-    setupFiles: [],
+    setupFiles: ['src/tests/setupEnv.ts'],
     testTimeout: 180000, // 2 minutes
     hookTimeout: 180000, // 1 minute for hooks (beforeAll, afterAll)
     teardownTimeout: 180000, // 100 seconds for cleanup


### PR DESCRIPTION
## Summary

- Add `sanitizeCollectionPayload` to normalize collection items before Postman API calls, ensuring folder nodes omit `request` and request leaves omit `item` (oneOf compliance)
- Make `putCollection` top-level item `id` optional so new folders/requests can be added without existing IDs
- Add schema validation tests and dist build coverage for folder support
- Add collection-level `noauth` to `putCollection` schema

Closes #142

## Test plan

- [x] Unit tests pass: `POSTMAN_API_KEY=test-key pnpm exec vitest run src/tests/unit/collectionItems.test.ts`
- [x] Build succeeds: `pnpm run build`
- [ ] Integration test `should create a collection with nested folder items` (requires `POSTMAN_API_KEY`)

## Note

Reopened after rewriting branch commit authors so contribution metadata matches the PR author account.