### PR TITLE
Edit readme for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Postman MCP Server connects Postman to AI tools, giving AI agents and assist
 
 Postman also offers the server as an [npm package](https://www.npmjs.com/package/@postman/postman-mcp-server).
 
-For the full installation guide with agent-specific setup, visit [**postman.com/product/mcp-server**](https://www.postman.com/product/mcp-server/).
+For the full installation guide with agent-specific setup, see Postman's [MCP Server product page](https://www.postman.com/product/mcp-server/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx @postman/postman-mcp-server
 
 Add `--code` or `--full` for Code or Full mode. Set `POSTMAN_API_KEY` as an environment variable.
 
-For IDE-specific setup instructions, see the table below. For more information, see the [Postman MCP Server docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview).
+For IDE-specific setup instructions, see the following table. For more information, see the [Postman MCP Server docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx @postman/postman-mcp-server
 
 Add `--code` or `--full` for Code or Full mode. Set `POSTMAN_API_KEY` as an environment variable.
 
-For IDE-specific setup instructions, see the table below. For more information, see the [Postman MCP Server docs](https://learning.postman.com/latest-v-12/docs/reference/postman-api/postman-mcp-server/overview).
+For IDE-specific setup instructions, see the table below. For more information, see the [Postman MCP Server docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview).
 
 ---
 
@@ -101,7 +101,7 @@ The Postman MCP Server supports the EU region for remote and local servers:
 
 ## Docker
 
-For Docker setup and installation, see [DOCKER.md](./DOCKER.md).
+For Docker setup and installation, see [DOCKER.md](https://github.com/postmanlabs/postman-mcp-server/blob/main/DOCKER.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Postman MCP Server
 
-The Postman MCP Server connects Postman to AI tools, giving AI agents and assistants the ability to access workspaces, manage collections and environments, evaluate APIs, and automate workflows through natural language interactions. Learn more on the [Postman MCP Server product page](https://www.postman.com/product/mcp-server/).
+The Postman MCP Server connects Postman to AI tools, giving AI agents and assistants the ability to access workspaces, manage collections and environments, evaluate APIs, and automate workflows through natural language interactions.
 
 Postman also offers the server as an [npm package](https://www.npmjs.com/package/@postman/postman-mcp-server).
+
+For the full installation guide with agent-specific setup, visit [**postman.com/product/mcp-server**](https://www.postman.com/product/mcp-server/).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@postman/postman-mcp-server",
   "version": "2.9.1",
-  "description": "A simple MCP server to operate on the Postman API",
+  "description": "MCP server for Postman — connect AI agents to your workspaces, collections, and APIs",
   "mcpName": "com.postman/postman-mcp-server",
   "main": "dist/src/index.js",
   "type": "module",
@@ -60,5 +60,5 @@
   "bugs": {
     "url": "https://github.com/postmanlabs/postman-mcp-server/issues"
   },
-  "homepage": "https://github.com/postmanlabs/postman-mcp-server#readme"
+  "homepage": "https://www.postman.com/product/mcp-server/"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "keywords": ["mcp", "model-context-protocol", "postman", "ai", "llm", "tools"],
   "author": "Postman, Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     "node": ">=20.0.0"
   },
   "keywords": ["mcp", "model-context-protocol", "postman", "ai", "llm", "tools"],
-  "author": "Postman, Inc.",
+  "author": {
+    "name": "Postman, Inc.",
+    "url": "https://www.postman.com"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Improves how the Postman MCP Server presents itself on npm and GitHub.
README:

1. Adds a dedicated hub link after the intro paragraph, pointing to postman.com/product/mcp-server for the full installation guide
2. Removes the inline "Learn more" link from the first paragraph (now redundant)
3. Fixes DOCKER.md link to an absolute GitHub URL (relative links break on npmjs.com)
4. Removes latest-v-12 version prefix from the docs URL to keep it evergreen

package.json:
1. Rewrites description from "A simple MCP server to operate on the Postman API" to something more descriptive and search-friendly
2. Adds keywords: mcp, model-context-protocol, postman, ai, llm, tools to improve npm search discoverability
3. Updates homepage to point to the product page instead of the GitHub README
4. Expands author to include a URL to postman.com