### PR TITLE
feat: package Learn toolset as .mcpb release asset

### DIFF
--- a/.github/workflows/mcpb-pack.yaml
+++ b/.github/workflows/mcpb-pack.yaml
@@ -46,6 +46,8 @@ jobs:
           mv manifest-full.tmp.json manifest-full.json
           jq --arg v "$pkg_version" '.version = $v' manifest-code.json > manifest-code.tmp.json
           mv manifest-code.tmp.json manifest-code.json
+          jq --arg v "$pkg_version" '.version = $v' manifest-learn.json > manifest-learn.tmp.json
+          mv manifest-learn.tmp.json manifest-learn.json
 
       - name: Build project
         run: pnpm run build
@@ -77,10 +79,16 @@ jobs:
           mcpb pack
           mv "${current_dir}.mcpb" "${current_dir}-code.mcpb"
 
+          # Package learn version
+          cp manifest-learn.json manifest.json
+          mcpb pack
+          mv "${current_dir}.mcpb" "${current_dir}-learn.mcpb"
+
           # Set environment variables
           echo "MCPB_MINIMAL_FILENAME=${current_dir}-minimal.mcpb" >> $GITHUB_ENV
           echo "MCPB_FULL_FILENAME=${current_dir}-full.mcpb" >> $GITHUB_ENV
           echo "MCPB_CODE_FILENAME=${current_dir}-code.mcpb" >> $GITHUB_ENV
+          echo "MCPB_LEARN_FILENAME=${current_dir}-learn.mcpb" >> $GITHUB_ENV
 
       - name: Upload minimal release asset
         uses: svenstaro/upload-release-action@7027b7670c56b9473901daad1fb8a09ab534688e
@@ -106,6 +114,15 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.MCPB_CODE_FILENAME }}
           asset_name: ${{ env.MCPB_CODE_FILENAME }}
+          tag: ${{ steps.release-tag.outputs.tag }}
+          overwrite: true
+
+      - name: Upload learn release asset
+        uses: svenstaro/upload-release-action@7027b7670c56b9473901daad1fb8a09ab534688e
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.MCPB_LEARN_FILENAME }}
+          asset_name: ${{ env.MCPB_LEARN_FILENAME }}
           tag: ${{ steps.release-tag.outputs.tag }}
           overwrite: true
 

--- a/manifest-learn.json
+++ b/manifest-learn.json
@@ -1,0 +1,67 @@
+{
+  "manifest_version": "0.2",
+  "version": "2.11.0",
+  "name": "postman-mcp-server-learn",
+  "display_name": "Postman MCP Server (Learn)",
+  "description": "Search the official Postman documentation and learning resources.",
+  "long_description": "This extension enables AI assistants to search the official Postman documentation and learning resources at https://learning.postman.com through Model Context Protocol (MCP). This learn version exposes a single tool for authoritative, up-to-date guidance on how to use Postman features. All secured with your Postman API key.",
+  "author": {
+    "name": "Postman, Inc.",
+    "email": "help@postman.com",
+    "url": "https://www.postman.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/postmanlabs/postman-mcp-server"
+  },
+  "homepage": "https://github.com/postmanlabs/postman-mcp-server",
+  "documentation": "https://learning.postman.com/docs/developer/postman-api/postman-mcp-server/overview",
+  "support": "https://github.com/postmanlabs/postman-api-mcp/issues",
+  "icon": "icon.png",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/src/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/src/index.js",
+        "--learn"
+      ],
+      "env": {
+        "POSTMAN_API_KEY": "${user_config.postman_api_key}"
+      }
+    }
+  },
+  "keywords": [
+    "postman",
+    "api",
+    "mcp",
+    "postman-api",
+    "documentation",
+    "learning-center",
+    "docs",
+    "learn"
+  ],
+  "license": "Apache-2.0",
+  "user_config": {
+    "postman_api_key": {
+      "type": "string",
+      "title": "Postman API Key",
+      "description": "A valid Postman API key used to authenticate requests.",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  },
+  "tools_generated": true
+}


### PR DESCRIPTION
## Summary

The `v2.11.0` release does not include a `.mcpb` bundle for the new **Learn** toolset. The server code already supports it (`--learn` flag → `enabledResources.learn` → `searchLearningCenter`), but the `Release MCPB` workflow only packaged the `minimal`, `full`, and `code` variants. This PR adds the missing Learn bundle.

## Changes

- Add `manifest-learn.json` following the existing manifest pattern, passing `--learn` to the server. `postman_api_key` is kept `required` for consistency with the other manifests and with server startup (`src/index.ts` exits if no API key is set, even in learn mode).
- Update `.github/workflows/mcpb-pack.yaml` to:
  - sync `manifest-learn.json` version with `package.json`
  - package the learn variant into `postman-mcp-server-learn.mcpb`
  - upload it as a release asset (`overwrite: true`)

## Notes

The workflow triggers on tag push, so this does not retroactively add the asset to the already-published `v2.11.0` release. The Learn bundle will be produced on the next tag, or the workflow can be run manually via `workflow_dispatch` (which resolves the latest release and uploads with `overwrite: true`, without re-publishing to the MCP Registry).