### PR TITLE
feat: automate Docker image build and Docker Hub publish on release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,46 @@
+name: Publish Docker image to Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: production
+          tags: |
+            mcp/postman:${{ steps.version.outputs.version }}
+            mcp/postman:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Add `docker-release.yml` workflow triggered on `v*` tags that builds and pushes the Docker image to Docker Hub (`mcp/postman`)
- Tags the image with both the release version (e.g. `1.12.9`) and `latest`
- Multi-arch build (amd64 + arm64) via Buildx + QEMU
- Uses GitHub Actions cache for faster subsequent builds
- Reuses the existing multi-stage `Dockerfile` (target: `production`)

## Prerequisites

- [ ] Configure `DOCKERHUB_USERNAME` secret in repo settings
- [ ] Configure `DOCKERHUB_TOKEN` secret in repo settings
- [ ] Verify Docker Hub org/repo access for `mcp/postman`

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` to validate the build succeeds
- [ ] Verify image is pushed to Docker Hub with correct tags
- [ ] Pull the image and confirm `--minimal`, `--full`, and `--code` flags work
- [ ] Verify multi-arch manifests are present (amd64 + arm64)