### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Postman MCP Server
 
+[![MCP Toplist](https://mcptoplist.com/badge/com.postman%2Fpostman-mcp-server.svg)](https://mcptoplist.com/server/com.postman%2Fpostman-mcp-server)
+
 The **Postman MCP Server** implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to connect AI agents and coding assistants — including Claude Code, Cursor, VS Code Copilot, GitHub Copilot CLI, and Gemini CLI — directly to your Postman workspaces, collections, specifications, and environments.
 
 Postman also offers the server as an [npm package](https://www.npmjs.com/package/@postman/postman-mcp-server).


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,919 MCP servers across the major
registries, and **Postman MCP Server** is currently ranked **#645**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/com.postman%2Fpostman-mcp-server.svg)](https://mcptoplist.com/server/com.postman%2Fpostman-mcp-server)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Postman MCP Server!
