### PR TITLE
docs: route per-agent setup to the install guide, and correct the registry record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Postman MCP Server
 
-The **Postman MCP Server** implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to connect AI agents and coding assistants — including Claude Code, Cursor, VS Code Copilot, GitHub Copilot CLI, and Gemini CLI — directly to your Postman workspaces, collections, specifications, and environments.
+The **Postman MCP Server** implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to connect AI agents and coding assistants — including Claude Code, Cursor, VS Code, GitHub Copilot CLI, Kiro, Codex CLI, Antigravity CLI, and Claude Desktop — directly to your Postman workspaces, collections, specifications, and environments.
 
 Postman also offers the server as an [npm package](https://www.npmjs.com/package/@postman/postman-mcp-server).
 
@@ -55,25 +55,31 @@ npx @postman/postman-mcp-server
 
 Add `--code` or `--full` for Code or Full mode. Set `POSTMAN_API_KEY` as an environment variable.
 
-For IDE-specific setup instructions, see the following table. For more information, see the [Postman MCP Server docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview).
+For per-agent setup — including one-click installs — see the [install guide](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install) or the table below. For more information, see the [Postman MCP Server docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview).
 
 ---
 
 ## Supported agents and IDEs
 
+Every agent below connects through one of the two entry points in [Quick start](#quick-start) above — the remote URL or the `npx` command. What differs per agent is where the config lives and whether a one-click install exists.
 
-| Agent / IDE | Remote | Local |
-| --- | --- | --- |
-| Claude Code        | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#claude-code)        | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#claude-code)        |
-| Claude Desktop     | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#claude) | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#claude)             |
-| Cursor             | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#cursor)             | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#cursor)             |
-| VS Code            | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#visual-studio-code) | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#visual-studio-code) |
-| Codex              | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#codex)              | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#codex)              |
-| Antigravity CLI       | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#antigravity-cli)        | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#antigravity-cli)        |
-| GitHub Copilot CLI | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#github-copilot-cli) | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#github-copilot-cli) |
-| Kiro               | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server#kiro)               | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#kiro)               |
-| Docker             | —                                                                                                                               | [Docs](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server#docker)             |
+The [**Postman MCP Server install guide**](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install) has the per-agent detail, and adds what a README cannot: one-click install buttons, and toggles for toolset, region and quiet mode that rewrite the command for you as you change them.
 
+| Agent / IDE | Per-agent setup | One-click install | Postman plugin |
+| --- | --- | --- | --- |
+| Claude Code | [Claude Code setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-claude-code) | — | Plugin |
+| Cursor | [Cursor setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-cursor) | Yes | Plugin |
+| VS Code | [VS Code setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-vscode) | Yes | Extension |
+| Copilot CLI | [Copilot CLI setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-copilot) | — | — |
+| Kiro | [Kiro setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-kiro) | Yes | Power |
+| Codex CLI | [Codex CLI setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-codex) | — | — |
+| Antigravity CLI | [Antigravity CLI setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-antigravity) | — | Extension |
+| Claude Desktop | [Claude Desktop setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-claude-desktop) | Yes | — |
+| Docker | [Docker setup →](https://www.postman.com/product/mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=mcp-server-install#install-docker) | — | — |
+
+Using a client that is not listed? Any MCP-compatible host works — point it at `https://mcp.postman.com/minimal`. The install guide has a generic `mcpServers` config for custom integrations.
+
+Reference documentation: [remote server](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-remote-server) · [local server](https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/postman-mcp-local-server)
 
 ---
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.postman/postman-mcp-server",
-  "description": "A basic MCP server to operate on the Postman API.",
+  "description": "Manage Postman collections, specs, environments and workspaces, and generate API client code.",
+  "title": "Postman",
+  "websiteUrl": "https://www.postman.com/product/mcp-server/",
   "repository": {
     "url": "https://github.com/postmanlabs/postman-mcp-server",
     "source": "github"
@@ -76,11 +78,59 @@
   "remotes": [
     {
       "type": "streamable-http",
+      "url": "https://mcp.postman.com/minimal",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "A Bearer token with a valid Postman API key. Optional on US endpoints, which also support OAuth.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.postman.com/code",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "A Bearer token with a valid Postman API key. Optional on US endpoints, which also support OAuth.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
       "url": "https://mcp.postman.com/mcp",
       "headers": [
         {
           "name": "Authorization",
-          "description": "A Bearer token and a valid Postman API key for authentication.",
+          "description": "A Bearer token with a valid Postman API key. Optional on US endpoints, which also support OAuth.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.postman.com/learn",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "A Bearer token with a valid Postman API key. Optional on US endpoints, which also support OAuth.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.eu.postman.com/minimal",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "A Bearer token with a valid Postman API key. Required \u2014 the EU endpoints do not support OAuth.",
           "isRequired": true,
           "isSecret": true
         }
@@ -88,11 +138,11 @@
     },
     {
       "type": "streamable-http",
-      "url": "https://mcp.postman.com/minimal",
+      "url": "https://mcp.eu.postman.com/code",
       "headers": [
         {
           "name": "Authorization",
-          "description": "A Bearer token and a valid Postman API key for authentication.",
+          "description": "A Bearer token with a valid Postman API key. Required \u2014 the EU endpoints do not support OAuth.",
           "isRequired": true,
           "isSecret": true
         }
@@ -104,7 +154,7 @@
       "headers": [
         {
           "name": "Authorization",
-          "description": "A Bearer token and a valid Postman API key for authentication.",
+          "description": "A Bearer token with a valid Postman API key. Required \u2014 the EU endpoints do not support OAuth.",
           "isRequired": true,
           "isSecret": true
         }
@@ -112,11 +162,11 @@
     },
     {
       "type": "streamable-http",
-      "url": "https://mcp.eu.postman.com/minimal",
+      "url": "https://mcp.eu.postman.com/learn",
       "headers": [
         {
           "name": "Authorization",
-          "description": "A Bearer token and a valid Postman API key for authentication.",
+          "description": "A Bearer token with a valid Postman API key. Required \u2014 the EU endpoints do not support OAuth.",
           "isRequired": true,
           "isSecret": true
         }


### PR DESCRIPTION
> **Reworked.** The first version of this PR duplicated the full per-agent command matrix into the README. That was the wrong call and this PR now does the opposite — see [Why the approach changed](#why-the-approach-changed).

## Summary

The **Supported agents and IDEs** table pointed all 9 clients at `learning.postman.com` and carried no per-agent detail, so a reader had to guess which of the two Quick start paths applied to their tool. The intro also still advertised Gemini CLI, which was removed from the supported set.

**README** — keep Quick start as the generic, always-completable path (remote URL or `npx`), and route the per-agent specifics to the install guide:

- Per-agent deep links to the guide's `#install-<agent>` anchors, with columns showing whether a one-click install and a Postman plugin / extension / power exist for that agent.
- UTM params on those links, so search → install attribution survives the hop from GitHub.
- The "IDE-specific setup" line now points at the guide rather than the table beneath it.
- Gemini CLI dropped from the intro.

**server.json** — the registry record feeds the MCP client install UIs and pulsemcp, lobehub, glama, cursor.directory and mcpservers.com, so these fields are what a discovering agent or catalog actually reads:

- `description` was *"A basic MCP server to operate on the Postman API."* — says nothing about what the server does. Replaced with a capability-led line, 93 chars against the schema's 100 cap.
- `title` added, so subregistries have a display name.
- `websiteUrl` was unset. The schema calls it out as "particularly useful when the server has custom installation instructions", which is exactly this server. **This is the field that sends registry and aggregator traffic to a surface we control and can measure.**
- `remotes` gained `/code` and `/learn` for US and EU. Only `/mcp` and `/minimal` were listed, so **two of the four toolsets were invisible** to anything discovering the server through the registry.
- `Authorization` `isRequired` was `true` on every endpoint, contradicting OAuth. Now `false` for US (OAuth needs no API key) and `true` for EU, which is API-key only.

Version, package identifiers and `fileSha256` are untouched — those belong to the release workflow.

## Why the approach changed

The original version put the resolved commands for all 9 agents directly in the README. Two problems with that:

1. **It does not help postman.com's SEO.** GitHub renders `rel="nofollow"` on every outbound README link — verified, all 35 of them. Nothing accrues to the product page. A better-ranking README helps `github.com`, which already ranks.
2. **It works against the funnel.** A self-sufficient README means the install completes on a surface with no one-click buttons, no toolset/region toggles, no telemetry-consent flow, and no instrumentation. First tool invocation is still measurable server-side at `mcp.postman.com`, but the *attribution* back to a search entry is lost — and that funnel is being built.

There is a real cost to the other extreme too: an agent that cannot complete an install from the README may fall back to a third party rather than fetch the page. In a SERP check on 2026-08-05, *"postman mcp server config cursor"* produced an answer that ended by telling the user to click "Connect next to Composio."

So this lands in the middle: **Quick start stays generic and always completable**, so no agent is ever stranded; **per-agent specifics route to the guide**, which is where the one-click buttons and live command rewriting are. The `#install-<agent>` anchors these links target are new — they ship in [marketing-site PR #3321](https://github.com/postman-eng/marketing-site-www-next-app/pull/3321), which makes the per-agent install content server-rendered for the first time.

## Issue

None

## Stakeholder

@christosgkoros

## Assignees

_None_

## Preview

N/A — no preview deploy in this repo. Rendered README on the branch: https://github.com/postmanlabs/postman-mcp-server/blob/docs/readme-per-agent-install-commands/README.md

## How to test

- [ ] Read the rendered README and confirm Quick start still gives a complete, runnable path for both remote and local without leaving the page
- [ ] Confirm all 9 per-agent links resolve, and that the One-click / Plugin columns match reality for each agent
- [ ] Confirm the `Authorization` `isRequired: false` claim for US remotes matches server behaviour (OAuth without an API key)
- [ ] `npx ajv-cli validate -s https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json -d server.json --strict=false`

## Test with Claude

```
Check out the `docs/readme-per-agent-install-commands` branch of postmanlabs/postman-mcp-server. Verify the README still lets a reader complete an install without leaving the file: the Quick start section must contain both a remote URL and a runnable npx command. Then confirm the "Supported agents and IDEs" table lists all 9 agents, that each links to a #install-<agent> anchor on www.postman.com/product/mcp-server/ carrying UTM params, and that the intro no longer mentions Gemini CLI. Report pass/fail with the agents and links you checked.
```

```
Still on that branch, review server.json against https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json. Confirm description is under the 100-character cap, websiteUrl and title are valid top-level fields, all four toolsets (/minimal, /code, /mcp, /learn) appear as remotes for both mcp.postman.com and mcp.eu.postman.com, and Authorization isRequired is false only for the US endpoints and true for the EU ones. Then confirm nothing owned by the release workflow changed — version, package identifiers and fileSha256 must match main. Report pass/fail with the fields you compared.
```

## Launch date

N/A

## Checklist

- [x] `server.json` validated against the published MCP schema
- [x] Quick start remains a complete, standalone install path
- [x] Per-agent links carry UTM params for funnel attribution
- [ ] `Authorization` `isRequired` change confirmed against server behaviour by a maintainer
- [ ] `#install-<agent>` anchors live — depends on [marketing-site #3321](https://github.com/postman-eng/marketing-site-www-next-app/pull/3321) shipping first
- [x] Kept as a **draft** while in progress; marked **ready for review** when it's ready

### Reviewer note on ordering

The per-agent links point at anchors that **do not exist on production yet**. Merge #3321 first, or the 9 table links will land at the top of the install guide rather than the relevant agent. Everything else here is independent.

Generated with [Claude Code](https://claude.com/claude-code)