### PR TITLE
fix: preserve nested collection request scripts

### DIFF
--- a/src/tools/createCollection.ts
+++ b/src/tools/createCollection.ts
@@ -3,6 +3,20 @@ import { PostmanAPIClient, ContentType } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
 
+const collectionItemEvent = z
+  .array(
+    z.object({
+      listen: z.enum(['test', 'prerequest']),
+      script: z
+        .object({
+          type: z.string().optional(),
+          exec: z.array(z.string().nullable()).optional(),
+        })
+        .optional(),
+    })
+  )
+  .describe('A list of scripts configured to run when specific events occur.');
+
 export const method = 'createCollection';
 export const title = 'Create a collection';
 export const description =
@@ -632,6 +646,7 @@ export const parameters = z.object({
                       .nullable()
                       .describe("The item's description.")
                       .optional(),
+                    event: collectionItemEvent.optional(),
                     request: z
                       .object({
                         url: z
@@ -716,6 +731,7 @@ export const parameters = z.object({
                               ])
                               .optional(),
                           })
+                          .passthrough()
                           .optional(),
                       })
                       .describe(
@@ -724,71 +740,84 @@ export const parameters = z.object({
                       .optional(),
                     item: z
                       .array(
-                        z.object({
-                          name: z.string().describe("The item's name.").optional(),
-                          description: z
-                            .string()
-                            .nullable()
-                            .describe("The item's description.")
-                            .optional(),
-                          request: z
-                            .object({
-                              url: z
-                                .union([z.string(), z.object({ raw: z.string().optional() })])
-                                .optional(),
-                              method: z
-                                .preprocess(
-                                  (v) => (typeof v === 'string' ? v.toUpperCase() : v),
-                                  z.enum([
-                                    'GET',
-                                    'PUT',
-                                    'POST',
-                                    'PATCH',
-                                    'DELETE',
-                                    'COPY',
-                                    'HEAD',
-                                    'OPTIONS',
-                                    'LINK',
-                                    'UNLINK',
-                                    'PURGE',
-                                    'LOCK',
-                                    'UNLOCK',
-                                    'PROPFIND',
-                                    'VIEW',
-                                  ])
-                                )
-                                .optional(),
-                              header: z
-                                .array(
-                                  z.object({
-                                    key: z.string().optional(),
-                                    value: z.string().optional(),
-                                  })
-                                )
-                                .optional(),
-                              body: z
-                                .object({ mode: z.string().optional(), raw: z.string().optional() })
-                                .optional(),
-                            })
-                            .describe('The request definition.')
-                            .optional(),
-                          item: z
-                            .array(
-                              z.object({
-                                name: z.string().optional(),
-                                request: z
+                        z
+                          .object({
+                            name: z.string().describe("The item's name.").optional(),
+                            description: z
+                              .string()
+                              .nullable()
+                              .describe("The item's description.")
+                              .optional(),
+                            event: collectionItemEvent.optional(),
+                            request: z
+                              .object({
+                                url: z
+                                  .union([z.string(), z.object({ raw: z.string().optional() })])
+                                  .optional(),
+                                method: z
+                                  .preprocess(
+                                    (v) => (typeof v === 'string' ? v.toUpperCase() : v),
+                                    z.enum([
+                                      'GET',
+                                      'PUT',
+                                      'POST',
+                                      'PATCH',
+                                      'DELETE',
+                                      'COPY',
+                                      'HEAD',
+                                      'OPTIONS',
+                                      'LINK',
+                                      'UNLINK',
+                                      'PURGE',
+                                      'LOCK',
+                                      'UNLOCK',
+                                      'PROPFIND',
+                                      'VIEW',
+                                    ])
+                                  )
+                                  .optional(),
+                                header: z
+                                  .array(
+                                    z.object({
+                                      key: z.string().optional(),
+                                      value: z.string().optional(),
+                                    })
+                                  )
+                                  .optional(),
+                                body: z
                                   .object({
-                                    url: z
-                                      .union([z.string(), z.object({ raw: z.string().optional() })])
-                                      .optional(),
-                                    method: z.string().optional(),
+                                    mode: z.string().optional(),
+                                    raw: z.string().optional(),
                                   })
                                   .optional(),
                               })
-                            )
-                            .describe('Further nested folder items.')
-                            .optional(),
-                        })
+                              .describe('The request definition.')
+                              .optional(),
+                            item: z
+                              .array(
+                                z
+                                  .object({
+                                    name: z.string().optional(),
+                                    event: collectionItemEvent.optional(),
+                                    request: z
+                                      .object({
+                                        url: z
+                                          .union([
+                                            z.string(),
+                                            z.object({ raw: z.string().optional() }),
+                                          ])
+                                          .optional(),
+                                        method: z.string().optional(),
+                                      })
+                                      .passthrough()
+                                      .optional(),
+                                  })
+                                  .passthrough()
+                              )
+                              .describe('Further nested folder items.')
+                              .optional(),
+                          })
+                          .passthrough()
                       )
                       .describe('Nested folder items for deeper folder structures.')
                       .optional(),

--- a/src/tools/putCollection.ts
+++ b/src/tools/putCollection.ts
@@ -3,6 +3,21 @@ import { PostmanAPIClient, ContentType } from '../clients/postman.js';
 import { IsomorphicHeaders, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ServerContext, asMcpError, McpError } from './utils/toolHelpers.js';
 
+const collectionItemEvent = z
+  .array(
+    z.object({
+      listen: z.enum(['test', 'prerequest']),
+      script: z
+        .object({
+          id: z.string().optional(),
+          type: z.string().optional(),
+          exec: z.array(z.string().nullable()).optional(),
+        })
+        .optional(),
+    })
+  )
+  .describe('A list of scripts configured to run when specific events occur.');
+
 export const method = 'putCollection';
 export const title = "Replace a collection's data";
 export const description =
@@ -776,6 +791,7 @@ export const parameters = z.object({
                       .nullable()
                       .describe("The item's description.")
                       .optional(),
+                    event: collectionItemEvent.optional(),
                     request: z
                       .object({
                         url: z
@@ -860,6 +876,7 @@ export const parameters = z.object({
                               ])
                               .optional(),
                           })
+                          .passthrough()
                           .optional(),
                       })
                       .describe(
@@ -868,73 +885,86 @@ export const parameters = z.object({
                       .optional(),
                     item: z
                       .array(
-                        z.object({
-                          id: z.string().describe("The collection item's ID.").optional(),
-                          name: z.string().describe("The item's name.").optional(),
-                          description: z
-                            .string()
-                            .nullable()
-                            .describe("The item's description.")
-                            .optional(),
-                          request: z
-                            .object({
-                              url: z
-                                .union([z.string(), z.object({ raw: z.string().optional() })])
-                                .optional(),
-                              method: z
-                                .preprocess(
-                                  (v) => (typeof v === 'string' ? v.toUpperCase() : v),
-                                  z.enum([
-                                    'GET',
-                                    'PUT',
-                                    'POST',
-                                    'PATCH',
-                                    'DELETE',
-                                    'COPY',
-                                    'HEAD',
-                                    'OPTIONS',
-                                    'LINK',
-                                    'UNLINK',
-                                    'PURGE',
-                                    'LOCK',
-                                    'UNLOCK',
-                                    'PROPFIND',
-                                    'VIEW',
-                                  ])
-                                )
-                                .optional(),
-                              header: z
-                                .array(
-                                  z.object({
-                                    key: z.string().optional(),
-                                    value: z.string().optional(),
-                                  })
-                                )
-                                .optional(),
-                              body: z
-                                .object({ mode: z.string().optional(), raw: z.string().optional() })
-                                .optional(),
-                            })
-                            .describe('The request definition.')
-                            .optional(),
-                          item: z
-                            .array(
-                              z.object({
-                                id: z.string().optional(),
-                                name: z.string().optional(),
-                                request: z
+                        z
+                          .object({
+                            id: z.string().describe("The collection item's ID.").optional(),
+                            name: z.string().describe("The item's name.").optional(),
+                            description: z
+                              .string()
+                              .nullable()
+                              .describe("The item's description.")
+                              .optional(),
+                            event: collectionItemEvent.optional(),
+                            request: z
+                              .object({
+                                url: z
+                                  .union([z.string(), z.object({ raw: z.string().optional() })])
+                                  .optional(),
+                                method: z
+                                  .preprocess(
+                                    (v) => (typeof v === 'string' ? v.toUpperCase() : v),
+                                    z.enum([
+                                      'GET',
+                                      'PUT',
+                                      'POST',
+                                      'PATCH',
+                                      'DELETE',
+                                      'COPY',
+                                      'HEAD',
+                                      'OPTIONS',
+                                      'LINK',
+                                      'UNLINK',
+                                      'PURGE',
+                                      'LOCK',
+                                      'UNLOCK',
+                                      'PROPFIND',
+                                      'VIEW',
+                                    ])
+                                  )
+                                  .optional(),
+                                header: z
+                                  .array(
+                                    z.object({
+                                      key: z.string().optional(),
+                                      value: z.string().optional(),
+                                    })
+                                  )
+                                  .optional(),
+                                body: z
                                   .object({
-                                    url: z
-                                      .union([z.string(), z.object({ raw: z.string().optional() })])
-                                      .optional(),
-                                    method: z.string().optional(),
+                                    mode: z.string().optional(),
+                                    raw: z.string().optional(),
                                   })
                                   .optional(),
                               })
-                            )
-                            .describe('Further nested folder items.')
-                            .optional(),
-                        })
+                              .describe('The request definition.')
+                              .optional(),
+                            item: z
+                              .array(
+                                z
+                                  .object({
+                                    id: z.string().optional(),
+                                    name: z.string().optional(),
+                                    event: collectionItemEvent.optional(),
+                                    request: z
+                                      .object({
+                                        url: z
+                                          .union([
+                                            z.string(),
+                                            z.object({ raw: z.string().optional() }),
+                                          ])
+                                          .optional(),
+                                        method: z.string().optional(),
+                                      })
+                                      .passthrough()
+                                      .optional(),
+                                  })
+                                  .passthrough()
+                              )
+                              .describe('Further nested folder items.')
+                              .optional(),
+                          })
+                          .passthrough()
                       )
                       .describe('Nested folder items for deeper folder structures.')
                       .optional(),


### PR DESCRIPTION
## What does this change?

Nested request items in `createCollection` and `putCollection` were silently losing `event` scripts and request authentication fields during Zod validation. This change explicitly accepts scripts at nested folder levels and preserves extensible nested Collection Format fields instead of stripping them before the API call.

Fixes: #181

## Type of change

- [ ] Documentation (README, CONTRIBUTING, DOCKER, SECURITY, issue/PR templates)
- [ ] Repository tooling (workflows, Dockerfile, lint/format config, manifests)
- [ ] Release plumbing
- [x] Other (schema fix for collection tools)

## Synced-path check

Files under `src/` and `dist/` are synced from Postman's internal source of truth. This change is intended to be applied to the upstream source definitions and regenerated into this repository.

- [ ] This PR does **not** change anything under `src/` or `dist/`.

## Checklist

- [x] One focused change
- [x] Branched off the latest `main`, no conflicts
- [x] Conventional Commits title (`fix:`, `feat:`, `docs:`, `chore:`, ...)
- [x] `pnpm typecheck` passes locally
- [x] `pnpm test:unit` passes locally (33 tests)
- [x] Targeted ESLint passes locally
- [x] No `dist/` files in the diff